### PR TITLE
Only trigger ci-unix-static on push to main or PR

### DIFF
--- a/.github/workflows/ci-unix-static.yml
+++ b/.github/workflows/ci-unix-static.yml
@@ -1,5 +1,9 @@
 name: CI Unix Static
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 permissions:
   contents: read


### PR DESCRIPTION
This avoids duplicate workflow entries in a Pull Request.  
The alternative would be to trigger only on push of any branch, because these are also displayed in Pull Requests, but maybe only if they are part of the same repository.