### PR TITLE
ci: Add rustfmt

### DIFF
--- a/.github/workflows/ci-rustfmt.yml
+++ b/.github/workflows/ci-rustfmt.yml
@@ -1,0 +1,18 @@
+name: CI Rustfmt
+on: pull_request
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
+        with:
+          toolchain: nightly
+          override: true
+          components: rustfmt
+      - uses: LoliGothick/rustfmt-check@a4e8cd355b46d060f9d41955d17b34e7dbc29fc3 # v0.4.2
+        with:
+            token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
It will run rustfmt on the diffs and fail if it finds any
failures.

Note that this action does not work as intended with PRs
created with forked repositories (because of a github
limitation). But it will still fail and we can see the
failures in the logs instead of it being posted as a review
comment.

Sample failing action:
https://github.com/webmproject/CrabbyAvif/actions/runs/8053598990