### PR TITLE
Replace unimplemented! by AvifError

### DIFF
--- a/src/reformat/alpha.rs
+++ b/src/reformat/alpha.rs
@@ -18,15 +18,10 @@ impl rgb::Image {
         match libyuv::process_alpha(self, true) {
             Ok(_) => {
                 self.alpha_premultiplied = true;
-                return Ok(());
+                Ok(())
             }
-            Err(err) => {
-                if err != AvifError::NotImplemented {
-                    return Err(err);
-                }
-            }
+            Err(err) => Err(err),
         }
-        unimplemented!("native alpha multiply implementation");
     }
 
     pub fn unpremultiply_alpha(&mut self) -> AvifResult<()> {
@@ -39,15 +34,10 @@ impl rgb::Image {
         match libyuv::process_alpha(self, false) {
             Ok(_) => {
                 self.alpha_premultiplied = false;
-                return Ok(());
+                Ok(())
             }
-            Err(err) => {
-                if err != AvifError::NotImplemented {
-                    return Err(err);
-                }
-            }
+            Err(err) => Err(err),
         }
-        unimplemented!("native alpha unmultiply implementation");
     }
 
     pub fn set_opaque(&mut self) -> AvifResult<()> {

--- a/src/reformat/rgb_impl.rs
+++ b/src/reformat/rgb_impl.rs
@@ -116,24 +116,23 @@ struct State {
 }
 
 fn identity_yuv8_to_rgb8_full_range(image: &image::Image, rgb: &mut rgb::Image) -> AvifResult<()> {
+    if image.yuv_format != PixelFormat::Yuv444 || rgb.format == Format::Rgb565 {
+        return Err(AvifError::NotImplemented);
+    }
+
     let r_offset = rgb.format.r_offset();
     let g_offset = rgb.format.g_offset();
     let b_offset = rgb.format.b_offset();
-    let rgb565 = rgb.format == Format::Rgb565;
     let channel_count = rgb.channel_count() as usize;
     for i in 0..image.height {
         let y = image.row(Plane::Y, i)?;
         let u = image.row(Plane::U, i)?;
         let v = image.row(Plane::V, i)?;
         let rgb_pixels = rgb.row_mut(i)?;
-        if rgb565 {
-            unimplemented!("rgb 565 is not implemented");
-        } else {
-            for j in 0..image.width as usize {
-                rgb_pixels[(j * channel_count) + r_offset] = v[j];
-                rgb_pixels[(j * channel_count) + g_offset] = y[j];
-                rgb_pixels[(j * channel_count) + b_offset] = u[j];
-            }
+        for j in 0..image.width as usize {
+            rgb_pixels[(j * channel_count) + r_offset] = v[j];
+            rgb_pixels[(j * channel_count) + g_offset] = y[j];
+            rgb_pixels[(j * channel_count) + b_offset] = u[j];
         }
     }
     Ok(())
@@ -145,11 +144,7 @@ pub fn yuv_to_rgb(image: &image::Image, rgb: &mut rgb::Image) -> AvifResult<()> 
         yuv: YuvColorSpaceInfo::create_from(image)?,
     };
     if state.yuv.mode == Mode::Identity {
-        if image.depth == 8
-            && rgb.depth == 8
-            && image.yuv_format == PixelFormat::Yuv444
-            && image.full_range
-        {
+        if image.depth == 8 && rgb.depth == 8 && image.full_range {
             return identity_yuv8_to_rgb8_full_range(image, rgb);
         }
         // TODO: Add more fast paths for identity.


### PR DESCRIPTION
There are only three `unimplemented!()` calls in CrabbyAvif.  
Use `Err(AvifError::NotImplemented)` everywhere for consistency.

Also refactor `identity_yuv8_to_rgb8_full_range()`.