### PR TITLE
Remove rgb::Image::ignore_alpha for simplicity

### DIFF
--- a/src/capi/reformat.rs
+++ b/src/capi/reformat.rs
@@ -41,7 +41,7 @@ impl From<rgb::Image> for avifRGBImage {
             format: rgb.format,
             chroma_upsampling: rgb.chroma_upsampling,
             chroma_downsampling: rgb.chroma_downsampling,
-            ignore_alpha: rgb.ignore_alpha,
+            ignore_alpha: false,
             alpha_premultiplied: rgb.alpha_premultiplied,
             is_float: rgb.is_float,
             max_threads: rgb.max_threads,
@@ -54,19 +54,36 @@ impl From<rgb::Image> for avifRGBImage {
 impl From<*mut avifRGBImage> for rgb::Image {
     fn from(rgb: *mut avifRGBImage) -> rgb::Image {
         let rgb = unsafe { &(*rgb) };
-        rgb::Image {
+        let dst = rgb::Image {
             width: rgb.width,
             height: rgb.height,
             depth: rgb.depth,
             format: rgb.format,
             chroma_upsampling: rgb.chroma_upsampling,
             chroma_downsampling: rgb.chroma_downsampling,
-            ignore_alpha: rgb.ignore_alpha,
             alpha_premultiplied: rgb.alpha_premultiplied,
             is_float: rgb.is_float,
             max_threads: rgb.max_threads,
             pixels: Some(Pixels::Pointer(rgb.pixels)),
             row_bytes: rgb.row_bytes,
+        };
+        let format = match (rgb.format, rgb.ignore_alpha) {
+            (rgb::Format::Rgb, _) => rgb::Format::Rgb,
+            (rgb::Format::Rgba, true) => rgb::Format::Rgb,
+            (rgb::Format::Rgba, false) => rgb::Format::Rgba,
+            (rgb::Format::Argb, true) => rgb::Format::Rgb,
+            (rgb::Format::Argb, false) => rgb::Format::Argb,
+            (rgb::Format::Bgr, _) => rgb::Format::Bgr,
+            (rgb::Format::Bgra, true) => rgb::Format::Bgr,
+            (rgb::Format::Bgra, false) => rgb::Format::Bgra,
+            (rgb::Format::Abgr, true) => rgb::Format::Bgr,
+            (rgb::Format::Abgr, false) => rgb::Format::Abgr,
+            (rgb::Format::Rgb565, _) => rgb::Format::Rgb565,
+        };
+        if format == rgb.format {
+            dst
+        } else {
+            dst.shuffle_channels_to(format).unwrap()
         }
     }
 }

--- a/src/capi/reformat.rs
+++ b/src/capi/reformat.rs
@@ -80,11 +80,7 @@ impl From<*mut avifRGBImage> for rgb::Image {
             (rgb::Format::Abgr, false) => rgb::Format::Abgr,
             (rgb::Format::Rgb565, _) => rgb::Format::Rgb565,
         };
-        if format == rgb.format {
-            dst
-        } else {
-            dst.shuffle_channels_to(format).unwrap()
-        }
+        dst.shuffle_channels_to(format).unwrap()
     }
 }
 

--- a/src/reformat/libyuv.rs
+++ b/src/reformat/libyuv.rs
@@ -322,16 +322,12 @@ fn find_conversion_function(
     }
 }
 
-pub fn yuv_to_rgb(
-    image: &image::Image,
-    rgb: &mut rgb::Image,
-    reformat_alpha: bool,
-) -> AvifResult<bool> {
+pub fn yuv_to_rgb(image: &image::Image, rgb: &mut rgb::Image) -> AvifResult<bool> {
     if rgb.depth != 8 || (image.depth != 8 && image.depth != 10 && image.depth != 12) {
         return Err(AvifError::NotImplemented);
     }
     let (matrix_yuv, matrix_yvu) = find_constants(image).ok_or(AvifError::NotImplemented)?;
-    let alpha_preferred = reformat_alpha && image.has_alpha();
+    let alpha_preferred = rgb.has_alpha() && image.has_alpha();
     let conversion_function =
         find_conversion_function(image.yuv_format, image.depth, rgb, alpha_preferred)
             .ok_or(AvifError::NotImplemented)?;

--- a/src/reformat/mod.rs
+++ b/src/reformat/mod.rs
@@ -16,11 +16,7 @@ pub mod libyuv {
     use crate::reformat::*;
     use crate::*;
 
-    pub fn yuv_to_rgb(
-        _image: &image::Image,
-        _rgb: &mut rgb::Image,
-        _reformat_alpha: bool,
-    ) -> AvifResult<bool> {
+    pub fn yuv_to_rgb(_image: &image::Image, _rgb: &mut rgb::Image) -> AvifResult<bool> {
         return Err(AvifError::NotImplemented);
     }
 

--- a/src/reformat/rgb.rs
+++ b/src/reformat/rgb.rs
@@ -324,7 +324,7 @@ impl Image {
             pixels: None,
             row_bytes: 0,
             ..self
-          };
+        };
         dst.allocate()?;
 
         let src_channel_count = self.channel_count();

--- a/src/reformat/rgb.rs
+++ b/src/reformat/rgb.rs
@@ -559,7 +559,7 @@ mod tests {
     }
 
     #[test]
-    fn channel_shuffling() {
+    fn shuffle_channels_to() {
         let image = Image {
             width: 1,
             height: 1,

--- a/src/reformat/rgb.rs
+++ b/src/reformat/rgb.rs
@@ -311,29 +311,6 @@ impl Image {
         Ok(())
     }
 
-    pub fn view(&self) -> Image {
-        Image {
-            width: self.width,
-            height: self.height,
-            depth: self.depth,
-            format: self.format,
-            chroma_upsampling: self.chroma_upsampling,
-            chroma_downsampling: self.chroma_downsampling,
-            alpha_premultiplied: self.alpha_premultiplied,
-            is_float: self.is_float,
-            max_threads: self.max_threads,
-            pixels: match &self.pixels {
-                Some(Pixels::Pointer(ptr)) => Some(Pixels::Pointer(*ptr)),
-                Some(Pixels::Buffer(vec)) => Some(Pixels::Pointer(vec.as_ptr() as *mut u8)),
-                Some(Pixels::Buffer16(vec)) => {
-                    Some(Pixels::Pointer(vec.as_ptr().cast::<u8>() as *mut u8))
-                }
-                None => None,
-            },
-            row_bytes: self.row_bytes,
-        }
-    }
-
     pub fn shuffle_channels_to(self, format: Format) -> AvifResult<Image> {
         if self.format == format {
             return Ok(self);

--- a/src/reformat/rgb.rs
+++ b/src/reformat/rgb.rs
@@ -343,18 +343,11 @@ impl Image {
         }
 
         let mut dst = Image {
-            width: self.width,
-            height: self.height,
-            depth: self.depth,
-            format: format,
-            chroma_upsampling: self.chroma_upsampling,
-            chroma_downsampling: self.chroma_downsampling,
-            alpha_premultiplied: self.alpha_premultiplied,
-            is_float: self.is_float,
-            max_threads: self.max_threads,
+            format,
             pixels: None,
             row_bytes: 0,
-        };
+            ..self
+          };
         dst.allocate()?;
 
         let src_channel_count = self.channel_count();

--- a/src/reformat/rgb.rs
+++ b/src/reformat/rgb.rs
@@ -334,9 +334,9 @@ impl Image {
         }
     }
 
-    pub fn shuffle_channels_to(&self, format: Format) -> AvifResult<Image> {
+    pub fn shuffle_channels_to(self, format: Format) -> AvifResult<Image> {
         if self.format == format {
-            return Ok(self.view());
+            return Ok(self);
         }
         if self.format == Format::Rgb565 || format == Format::Rgb565 {
             return Err(AvifError::NotImplemented);
@@ -415,6 +415,7 @@ mod tests {
     use crate::image::ALL_PLANES;
     use crate::image::MAX_PLANE_COUNT;
 
+    use test_case::test_case;
     use test_case::test_matrix;
 
     const WIDTH: usize = 3;
@@ -558,8 +559,10 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn shuffle_channels_to() {
+    #[test_case(Format::Rgba, &[0, 1, 2, 3])]
+    #[test_case(Format::Abgr, &[3, 2, 1, 0])]
+    #[test_case(Format::Rgb, &[0, 1, 2])]
+    fn shuffle_channels_to(format: Format, expected: &[u8]) {
         let image = Image {
             width: 1,
             height: 1,
@@ -569,16 +572,9 @@ mod tests {
             row_bytes: 4,
             ..Default::default()
         };
-
-        for (format, expected) in [
-            (Format::Rgba, vec![0u8, 1, 2, 3]),
-            (Format::Abgr, vec![3u8, 2, 1, 0]),
-            (Format::Rgb, vec![0u8, 1, 2]),
-        ] {
-            assert_eq!(
-                image.shuffle_channels_to(format).unwrap().row(0).unwrap(),
-                expected
-            );
-        }
+        assert_eq!(
+            image.shuffle_channels_to(format).unwrap().row(0).unwrap(),
+            expected
+        );
     }
 }

--- a/src/reformat/rgb.rs
+++ b/src/reformat/rgb.rs
@@ -570,25 +570,15 @@ mod tests {
             ..Default::default()
         };
 
-        let shuffled = image.shuffle_channels_to(Format::Rgba);
-        match &shuffled.unwrap().pixels {
-            Some(Pixels::Pointer(ptr)) => assert_eq!(
-                unsafe { std::slice::from_raw_parts(*ptr, 4) },
-                [0u8, 1, 2, 3]
-            ),
-            _ => panic!(),
-        }
-
-        let shuffled = image.shuffle_channels_to(Format::Abgr);
-        match &shuffled.unwrap().pixels {
-            Some(Pixels::Buffer(vec)) => assert_eq!(vec[..], [3u8, 2, 1, 0]),
-            _ => panic!(),
-        }
-
-        let shuffled = image.shuffle_channels_to(Format::Rgb);
-        match &shuffled.unwrap().pixels {
-            Some(Pixels::Buffer(vec)) => assert_eq!(vec[..], [0u8, 1, 2]),
-            _ => panic!(),
+        for (format, expected) in [
+            (Format::Rgba, vec![0u8, 1, 2, 3]),
+            (Format::Abgr, vec![3u8, 2, 1, 0]),
+            (Format::Rgb, vec![0u8, 1, 2]),
+        ] {
+            assert_eq!(
+                image.shuffle_channels_to(format).unwrap().row(0).unwrap(),
+                expected
+            );
         }
     }
 }


### PR DESCRIPTION
rgb::Image::format can be set to an opaque format instead.

Also do not premultiply samples with alpha before dropping alpha. This is not a behavior I would expect.