### PR TITLE
ci: Avoid explicit mkdir and cd

### DIFF
--- a/.github/workflows/ci-unix-static.yml
+++ b/.github/workflows/ci-unix-static.yml
@@ -68,8 +68,6 @@ jobs:
       if: runner.os == 'Linux'
       run: |
         cargo build --features capi --release
-        mkdir c_build
-        cd c_build
-        cmake ../c_api_tests/
-        make
-        make test
+        cmake -S c_api_tests -B c_build
+        make -C c_build
+        make -C c_build test


### PR DESCRIPTION
Use cmake with -B and make with -C.