### PR TITLE
Allow building the library without libyuv

### DIFF
--- a/.github/workflows/ci-unix-static-no-default-features.yml
+++ b/.github/workflows/ci-unix-static-no-default-features.yml
@@ -1,0 +1,32 @@
+name: CI Unix Static Without Default Features
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+# Cancel the workflow if a new one is triggered from the same PR, branch, or tag, except on main.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  build-static-no-default-features:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+    steps:
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+    - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
+      with:
+        toolchain: stable
+
+    - name: Build the library without default features
+      run: cargo build --no-default-features

--- a/src/reformat/mod.rs
+++ b/src/reformat/mod.rs
@@ -1,14 +1,58 @@
-// TODO: for now conversion is available only with libyuv.
-
 #[cfg(feature = "libyuv")]
 pub mod alpha;
 #[cfg(feature = "libyuv")]
-pub mod coeffs;
-#[cfg(feature = "libyuv")]
 pub mod libyuv;
 #[cfg(feature = "libyuv")]
-pub mod rgb;
-#[cfg(feature = "libyuv")]
-pub mod rgb_impl;
-#[cfg(feature = "libyuv")]
 pub mod scale;
+
+pub mod coeffs;
+pub mod rgb;
+pub mod rgb_impl;
+
+// If libyuv is not present, add placeholder functions so that the library will build successfully
+// without it.
+#[cfg(not(feature = "libyuv"))]
+pub mod libyuv {
+    use crate::reformat::*;
+    use crate::*;
+
+    pub fn yuv_to_rgb(
+        _image: &image::Image,
+        _rgb: &mut rgb::Image,
+        _reformat_alpha: bool,
+    ) -> AvifResult<bool> {
+        return Err(AvifError::NotImplemented);
+    }
+
+    pub fn process_alpha(_rgb: &mut rgb::Image, _multiply: bool) -> AvifResult<()> {
+        return Err(AvifError::NotImplemented);
+    }
+
+    pub fn convert_to_half_float(_rgb: &mut rgb::Image, _scale: f32) -> AvifResult<()> {
+        return Err(AvifError::NotImplemented);
+    }
+
+    impl image::Image {
+        pub fn alpha_to_full_range(&mut self) -> AvifResult<()> {
+            return Err(AvifError::NotImplemented);
+        }
+        pub fn scale(&mut self, _width: u32, _height: u32) -> AvifResult<()> {
+            return Err(AvifError::NotImplemented);
+        }
+    }
+
+    impl rgb::Image {
+        pub fn premultiply_alpha(&mut self) -> AvifResult<()> {
+            return Err(AvifError::NotImplemented);
+        }
+        pub fn unpremultiply_alpha(&mut self) -> AvifResult<()> {
+            return Err(AvifError::NotImplemented);
+        }
+        pub fn set_opaque(&mut self) -> AvifResult<()> {
+            return Err(AvifError::NotImplemented);
+        }
+        pub fn import_alpha_from(&mut self, _image: &image::Image) -> AvifResult<()> {
+            return Err(AvifError::NotImplemented);
+        }
+    }
+}


### PR DESCRIPTION
Add stub methods that will simply return error when built without libyuv.

Also add a CI to make sure we are able to build the library this way.