### PR TITLE
ci: Ensure that avif.h is kept up to date

### DIFF
--- a/.github/workflows/ci-c-header-file.yml
+++ b/.github/workflows/ci-c-header-file.yml
@@ -1,0 +1,31 @@
+name: CI C Header File
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+# Cancel the workflow if a new one is triggered from the same PR, branch, or tag, except on main.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  c-header-file:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+    - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
+      with:
+        toolchain: stable
+
+    - name: Build and the C header file
+      run: cargo build --features capi --release --no-default-features
+
+    - name: Ensure that there is no diff in the header file.
+      run: git diff --exit-code include/avif/avif.h


### PR DESCRIPTION
This file is used by C/C++ libraries that need to depend on
CrabbyAvif.

It is generated by using cbindgen and is checked into the
repository so that apps that don't use the cargo build system do
not have to build it separately.

This CI makes sure that the header file is in sync with any
changes to the rust code.


Sample failure:
https://github.com/webmproject/CrabbyAvif/actions/runs/8056858827