### PR TITLE
Remove byteorder dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ edition = "2021"
 crate-type = ["rlib", "cdylib"]
 
 [dependencies]
-byteorder = "1.5.0"
 libc = {version = "0.2.152", optional = true}
 ndk-sys = {version = "0.1.0", path="sys/ndk-sys", optional = true}
 dav1d-sys = { version = "0.1.0", path="sys/dav1d-sys", optional = true}

--- a/src/utils/raw.rs
+++ b/src/utils/raw.rs
@@ -5,8 +5,6 @@ use crate::reformat::rgb;
 use std::fs::File;
 use std::io::prelude::*;
 
-use byteorder::{BigEndian, WriteBytesExt};
-
 #[derive(Default)]
 pub struct RawWriter {
     pub filename: Option<String>,
@@ -59,7 +57,7 @@ impl RawWriter {
                     let row = rgb.row16(y).unwrap();
                     let mut row16: Vec<u8> = Vec::new();
                     for &pixel in row {
-                        let _ = row16.write_u16::<BigEndian>(pixel);
+                        row16.extend_from_slice(&pixel.to_be_bytes());
                     }
                     if self.file.as_ref().unwrap().write_all(&row16[..]).is_err() {
                         return false;

--- a/src/utils/y4m.rs
+++ b/src/utils/y4m.rs
@@ -3,8 +3,6 @@ use crate::*;
 use std::fs::File;
 use std::io::prelude::*;
 
-use byteorder::{LittleEndian, WriteBytesExt};
-
 #[derive(Default)]
 pub struct Y4MWriter {
     pub filename: Option<String>,
@@ -140,7 +138,7 @@ impl Y4MWriter {
                     let mut pixels: Vec<u8> = Vec::new();
                     // y4m is always little endian.
                     for &pixel16 in pixels16 {
-                        let _ = pixels.write_u16::<LittleEndian>(pixel16);
+                        pixels.extend_from_slice(&pixel16.to_le_bytes());
                     }
                     if self.file.as_ref().unwrap().write_all(&pixels[..]).is_err() {
                         return false;


### PR DESCRIPTION
We only use byteorder crate to read some big endian values for MP4 box parsing. Most of those can be done using the std library functions itself.

The only exception is read_uxx which needs a couple of lines more of code (+ tests).

byteorder crate has some unsafe usage which we don't really need to bother ourselves with for our use.