### PR TITLE
Add type definition to a potentially complex type

### DIFF
--- a/src/internal_utils/pixels.rs
+++ b/src/internal_utils/pixels.rs
@@ -10,6 +10,9 @@ pub enum Pixels {
     Buffer16(Vec<u16>),
 }
 
+pub type U8OrU16Slice<'a> = (Option<&'a [u8]>, Option<&'a [u16]>);
+pub type U8OrU16SliceMut<'a> = (Option<&'a mut [u8]>, Option<&'a mut [u16]>);
+
 impl Pixels {
     pub fn size(&self) -> usize {
         match self {
@@ -131,7 +134,7 @@ impl Pixels {
         }
     }
 
-    pub fn slices(&self, offset: u32, size: u32) -> AvifResult<(Option<&[u8]>, Option<&[u16]>)> {
+    pub fn slices(&self, offset: u32, size: u32) -> AvifResult<U8OrU16Slice> {
         match self {
             Pixels::Pointer(ptr) => {
                 let offset = isize_from_u32(offset)?;
@@ -149,11 +152,7 @@ impl Pixels {
         }
     }
 
-    pub fn slices_mut(
-        &mut self,
-        offset: u32,
-        size: u32,
-    ) -> AvifResult<(Option<&mut [u8]>, Option<&mut [u16]>)> {
+    pub fn slices_mut(&mut self, offset: u32, size: u32) -> AvifResult<U8OrU16SliceMut> {
         match self {
             Pixels::Pointer(ptr) => {
                 let offset = isize_from_u32(offset)?;

--- a/src/reformat/rgb.rs
+++ b/src/reformat/rgb.rs
@@ -170,7 +170,7 @@ impl Image {
         }
     }
 
-    pub fn rows_mut(&mut self, row: u32) -> AvifResult<(Option<&mut [u8]>, Option<&mut [u16]>)> {
+    pub fn rows_mut(&mut self, row: u32) -> AvifResult<U8OrU16SliceMut> {
         if self.depth == 8 {
             Ok((Some(self.row_mut(row)?), None))
         } else {


### PR DESCRIPTION
clippy complains that this type is too complex (which is true).

There might be better ways of abstracting this, but for now this gets rid of the clippy warning.