### PR TITLE
Refactor libyuv guard to be a bit more granular

### DIFF
--- a/src/reformat/alpha.rs
+++ b/src/reformat/alpha.rs
@@ -1,4 +1,6 @@
+#[cfg(feature = "libyuv")]
 use super::libyuv;
+
 use super::rgb;
 
 use crate::decoder::Category;
@@ -15,6 +17,7 @@ impl rgb::Image {
         if !self.has_alpha() || self.alpha_premultiplied {
             return Err(AvifError::InvalidArgument);
         }
+        #[cfg(feature = "libyuv")]
         match libyuv::process_alpha(self, true) {
             Ok(_) => {
                 self.alpha_premultiplied = true;
@@ -22,6 +25,8 @@ impl rgb::Image {
             }
             Err(err) => Err(err),
         }
+        #[cfg(not(feature = "libyuv"))]
+        Err(AvifError::NotImplemented)
     }
 
     pub fn unpremultiply_alpha(&mut self) -> AvifResult<()> {
@@ -31,6 +36,7 @@ impl rgb::Image {
         if !self.has_alpha() || !self.alpha_premultiplied {
             return Err(AvifError::InvalidArgument);
         }
+        #[cfg(feature = "libyuv")]
         match libyuv::process_alpha(self, false) {
             Ok(_) => {
                 self.alpha_premultiplied = false;
@@ -38,6 +44,8 @@ impl rgb::Image {
             }
             Err(err) => Err(err),
         }
+        #[cfg(not(feature = "libyuv"))]
+        Err(AvifError::NotImplemented)
     }
 
     pub fn set_opaque(&mut self) -> AvifResult<()> {

--- a/src/reformat/mod.rs
+++ b/src/reformat/mod.rs
@@ -1,10 +1,9 @@
 #[cfg(feature = "libyuv")]
-pub mod alpha;
-#[cfg(feature = "libyuv")]
 pub mod libyuv;
 #[cfg(feature = "libyuv")]
 pub mod scale;
 
+pub mod alpha;
 pub mod coeffs;
 pub mod rgb;
 pub mod rgb_impl;
@@ -20,34 +19,12 @@ pub mod libyuv {
         Err(AvifError::NotImplemented)
     }
 
-    pub fn process_alpha(_rgb: &mut rgb::Image, _multiply: bool) -> AvifResult<()> {
-        Err(AvifError::NotImplemented)
-    }
-
     pub fn convert_to_half_float(_rgb: &mut rgb::Image, _scale: f32) -> AvifResult<()> {
         Err(AvifError::NotImplemented)
     }
 
     impl image::Image {
-        pub fn alpha_to_full_range(&mut self) -> AvifResult<()> {
-            Err(AvifError::NotImplemented)
-        }
         pub fn scale(&mut self, _width: u32, _height: u32) -> AvifResult<()> {
-            Err(AvifError::NotImplemented)
-        }
-    }
-
-    impl rgb::Image {
-        pub fn premultiply_alpha(&mut self) -> AvifResult<()> {
-            Err(AvifError::NotImplemented)
-        }
-        pub fn unpremultiply_alpha(&mut self) -> AvifResult<()> {
-            Err(AvifError::NotImplemented)
-        }
-        pub fn set_opaque(&mut self) -> AvifResult<()> {
-            Err(AvifError::NotImplemented)
-        }
-        pub fn import_alpha_from(&mut self, _image: &image::Image) -> AvifResult<()> {
             Err(AvifError::NotImplemented)
         }
     }


### PR DESCRIPTION
Some of the alpha processing functions are not really dependent on libyuv but are still guarded by libyuv availability. Remove the module level guard and replace it with function level guards.

This will let us build the library with --no-default-features without any warnings.