### PR TITLE
rgb_impl: Remove unnecessary & for table_uv

### DIFF
--- a/src/reformat/rgb_impl.rs
+++ b/src/reformat/rgb_impl.rs
@@ -281,8 +281,8 @@ pub fn yuv_to_rgb_any(
                         ChromaUpsampling::Fastest | ChromaUpsampling::Nearest
                     )
                 {
-                    cb = unorm_value(&u_row, uv_i, yuv_max_channel, &table_uv);
-                    cr = unorm_value(&v_row, uv_i, yuv_max_channel, &table_uv);
+                    cb = unorm_value(&u_row, uv_i, yuv_max_channel, table_uv);
+                    cr = unorm_value(&v_row, uv_i, yuv_max_channel, table_uv);
                 } else {
                     if image.chroma_sample_position != ChromaSamplePosition::CENTER {
                         return Err(AvifError::NotImplemented);
@@ -312,14 +312,14 @@ pub fn yuv_to_rgb_any(
                     let v_adj_row = image.row_generic(Plane::V, uv_adj_j);
                     let mut unorm_u: [[f32; 2]; 2] = [[0.0; 2]; 2];
                     let mut unorm_v: [[f32; 2]; 2] = [[0.0; 2]; 2];
-                    unorm_u[0][0] = unorm_value(&u_row, uv_i, yuv_max_channel, &table_uv);
-                    unorm_v[0][0] = unorm_value(&v_row, uv_i, yuv_max_channel, &table_uv);
-                    unorm_u[1][0] = unorm_value(&u_row, uv_adj_i, yuv_max_channel, &table_uv);
-                    unorm_v[1][0] = unorm_value(&v_row, uv_adj_i, yuv_max_channel, &table_uv);
-                    unorm_u[0][1] = unorm_value(&u_adj_row, uv_i, yuv_max_channel, &table_uv);
-                    unorm_v[0][1] = unorm_value(&v_adj_row, uv_i, yuv_max_channel, &table_uv);
-                    unorm_u[1][1] = unorm_value(&u_adj_row, uv_adj_i, yuv_max_channel, &table_uv);
-                    unorm_v[1][1] = unorm_value(&v_adj_row, uv_adj_i, yuv_max_channel, &table_uv);
+                    unorm_u[0][0] = unorm_value(&u_row, uv_i, yuv_max_channel, table_uv);
+                    unorm_v[0][0] = unorm_value(&v_row, uv_i, yuv_max_channel, table_uv);
+                    unorm_u[1][0] = unorm_value(&u_row, uv_adj_i, yuv_max_channel, table_uv);
+                    unorm_v[1][0] = unorm_value(&v_row, uv_adj_i, yuv_max_channel, table_uv);
+                    unorm_u[0][1] = unorm_value(&u_adj_row, uv_i, yuv_max_channel, table_uv);
+                    unorm_v[0][1] = unorm_value(&v_adj_row, uv_i, yuv_max_channel, table_uv);
+                    unorm_u[1][1] = unorm_value(&u_adj_row, uv_adj_i, yuv_max_channel, table_uv);
+                    unorm_v[1][1] = unorm_value(&v_adj_row, uv_adj_i, yuv_max_channel, table_uv);
                     cb = (unorm_u[0][0] * (9.0 / 16.0))
                         + (unorm_u[1][0] * (3.0 / 16.0))
                         + (unorm_u[0][1] * (3.0 / 16.0))


### PR DESCRIPTION
After PR #46, table_uv is already a reference and there is no
need to use it as `&table_uv`. Fixes clippy warnings.
