### PR TITLE
Rewrite pointer access and remove unnecessary intermediates

### DIFF
--- a/src/capi/image.rs
+++ b/src/capi/image.rs
@@ -184,20 +184,18 @@ impl From<&Image> for avifImage {
             if !image.has_plane(i.into()) {
                 continue;
             }
-            let plane = image.plane(i.into()).unwrap();
-            dst_image.yuvPlanes[i] = if image.depth == 8 {
-                plane.data.unwrap().as_ptr() as *mut u8
+            dst_image.yuvPlanes[i] = if image.depth > 8 {
+                image.planes2[i].as_ref().unwrap().ptr16() as *mut u8
             } else {
-                plane.data16.unwrap().as_ptr() as *mut u8
+                image.planes2[i].as_ref().unwrap().ptr() as *mut u8
             };
             dst_image.yuvRowBytes[i] = image.row_bytes[i];
         }
         if image.has_plane(Plane::A) {
-            let plane = image.plane(Plane::A).unwrap();
-            dst_image.alphaPlane = if image.depth == 8 {
-                plane.data.unwrap().as_ptr() as *mut u8
+            dst_image.alphaPlane = if image.depth > 8 {
+                image.planes2[3].as_ref().unwrap().ptr16() as *mut u8
             } else {
-                plane.data16.unwrap().as_ptr() as *mut u8
+                image.planes2[3].as_ref().unwrap().ptr() as *mut u8
             };
             dst_image.alphaRowBytes = image.row_bytes[3];
         }

--- a/src/codecs/dav1d.rs
+++ b/src/codecs/dav1d.rs
@@ -143,7 +143,11 @@ impl Decoder for Dav1d {
                 image.width = dav1d_picture.p.w as u32;
                 image.height = dav1d_picture.p.h as u32;
                 image.depth = dav1d_picture.p.bpc as u8;
-                image.planes2[3] = Some(Pixels::Pointer(dav1d_picture.data[0] as *mut u8));
+                image.planes2[3] = Some(if image.depth > 8 {
+                    Pixels::Pointer16(dav1d_picture.data[0] as *mut u16)
+                } else {
+                    Pixels::Pointer(dav1d_picture.data[0] as *mut u8)
+                });
                 image.row_bytes[3] = dav1d_picture.stride[0] as u32;
                 image.image_owns_planes[3] = false;
                 let seq_hdr = unsafe { &(*dav1d_picture.seq_hdr) };
@@ -170,8 +174,11 @@ impl Decoder for Dav1d {
                 image.matrix_coefficients = (seq_hdr.mtrx as u16).into();
 
                 for plane in 0usize..image.yuv_format.plane_count() {
-                    image.planes2[plane] =
-                        Some(Pixels::Pointer(dav1d_picture.data[plane] as *mut u8));
+                    image.planes2[plane] = Some(if image.depth > 8 {
+                        Pixels::Pointer16(dav1d_picture.data[plane] as *mut u16)
+                    } else {
+                        Pixels::Pointer(dav1d_picture.data[plane] as *mut u8)
+                    });
                     let stride_index = if plane == 0 { 0 } else { 1 };
                     image.row_bytes[plane] = dav1d_picture.stride[stride_index] as u32;
                     image.image_owns_planes[plane] = false;

--- a/src/codecs/libgav1.rs
+++ b/src/codecs/libgav1.rs
@@ -108,7 +108,11 @@ impl Decoder for Libgav1 {
                     image.width = gav1_image.displayed_width[0] as u32;
                     image.height = gav1_image.displayed_height[0] as u32;
                     image.depth = gav1_image.bitdepth as u8;
-                    image.planes2[3] = Some(Pixels::Pointer(gav1_image.plane[0] as *mut u8));
+                    image.planes2[3] = Some(if image.depth > 8 {
+                        Pixels::Pointer16(gav1_image.plane[0] as *mut u16)
+                    } else {
+                        Pixels::Pointer(gav1_image.plane[0] as *mut u8)
+                    });
                     image.row_bytes[3] = gav1_image.stride[0] as u32;
                     image.image_owns_planes[3] = false;
                     image.full_range =
@@ -138,8 +142,11 @@ impl Decoder for Libgav1 {
                     image.matrix_coefficients = (gav1_image.matrix_coefficients as u16).into();
 
                     for plane in 0usize..image.yuv_format.plane_count() {
-                        image.planes2[plane] =
-                            Some(Pixels::Pointer(gav1_image.plane[plane] as *mut u8));
+                        image.planes2[plane] = Some(if image.depth > 8 {
+                            Pixels::Pointer16(gav1_image.plane[plane] as *mut u16)
+                        } else {
+                            Pixels::Pointer(gav1_image.plane[plane] as *mut u8)
+                        });
                         image.row_bytes[plane] = gav1_image.stride[plane] as u32;
                         image.image_owns_planes[plane] = false;
                     }

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -1212,7 +1212,7 @@ impl Decoder {
                             self.image.height = tile.image.height;
                             self.image.depth = tile.image.depth;
                             self.image.yuv_format = tile.image.yuv_format;
-                            self.image.steal_from(&tile.image, category);
+                            self.image.steal_from(&tile.image, category)?;
                             self.image.scale(tile.width, tile.height)?;
                         }
                         Category::Alpha => {
@@ -1220,7 +1220,7 @@ impl Decoder {
                                 println!("Color image item does not match alpha image item");
                                 return Err(AvifError::DecodeAlphaFailed);
                             }
-                            self.image.steal_from(&tile.image, category);
+                            self.image.steal_from(&tile.image, category)?;
                             if !tile.image.full_range {
                                 self.image.alpha_to_full_range()?;
                             }
@@ -1231,7 +1231,7 @@ impl Decoder {
                             self.gainmap.image.height = tile.image.height;
                             self.gainmap.image.depth = tile.image.depth;
                             self.gainmap.image.yuv_format = tile.image.yuv_format;
-                            self.gainmap.image.steal_from(&tile.image, category);
+                            self.gainmap.image.steal_from(&tile.image, category)?;
                             self.gainmap.image.scale(tile.width, tile.height)?;
                         }
                     }

--- a/src/internal_utils/mod.rs
+++ b/src/internal_utils/mod.rs
@@ -112,6 +112,7 @@ conversion_function!(u32_from_i32, u32, i32);
 conversion_function!(i32_from_u32, i32, u32);
 #[cfg(feature = "android_mediacodec")]
 conversion_function!(isize_from_i32, isize, i32);
+#[cfg(feature = "capi")]
 conversion_function!(isize_from_u32, isize, u32);
 conversion_function!(isize_from_usize, isize, usize);
 

--- a/src/internal_utils/pixels.rs
+++ b/src/internal_utils/pixels.rs
@@ -2,21 +2,21 @@ use crate::internal_utils::*;
 use crate::*;
 
 pub enum Pixels {
-    // Intended for use from the C API. Used for all bitdepths.
+    // Intended for use from the C API. Used for 8-bit images.
     Pointer(*mut u8),
+    // Intended for use from the C API. Used for 10-bit, 12-bit and 16-bit images.
+    Pointer16(*mut u16),
     // Used for 8-bit images.
     Buffer(Vec<u8>),
     // Used for 10-bit, 12-bit and 16-bit images.
     Buffer16(Vec<u16>),
 }
 
-pub type U8OrU16Slice<'a> = (Option<&'a [u8]>, Option<&'a [u16]>);
-pub type U8OrU16SliceMut<'a> = (Option<&'a mut [u8]>, Option<&'a mut [u16]>);
-
 impl Pixels {
     pub fn size(&self) -> usize {
         match self {
             Pixels::Pointer(_) => 0,
+            Pixels::Pointer16(_) => 0,
             Pixels::Buffer(buffer) => buffer.len(),
             Pixels::Buffer16(buffer) => buffer.len(),
         }
@@ -25,6 +25,7 @@ impl Pixels {
     pub fn pixel_bit_size(&self) -> usize {
         match self {
             Pixels::Pointer(_) => 0,
+            Pixels::Pointer16(_) => 0,
             Pixels::Buffer(_) => 8,
             Pixels::Buffer16(_) => 16,
         }
@@ -33,6 +34,7 @@ impl Pixels {
     pub fn has_data(&self) -> bool {
         match self {
             Pixels::Pointer(ptr) => !ptr.is_null(),
+            Pixels::Pointer16(ptr) => !ptr.is_null(),
             Pixels::Buffer(buffer) => !buffer.is_empty(),
             Pixels::Buffer16(buffer) => !buffer.is_empty(),
         }
@@ -41,6 +43,7 @@ impl Pixels {
     pub fn resize(&mut self, size: usize, default: u16) -> AvifResult<()> {
         match self {
             Pixels::Pointer(_) => return Err(AvifError::InvalidArgument),
+            Pixels::Pointer16(_) => return Err(AvifError::InvalidArgument),
             Pixels::Buffer(buffer) => {
                 if buffer.capacity() < size && buffer.try_reserve_exact(size).is_err() {
                     return Err(AvifError::OutOfMemory);
@@ -58,13 +61,46 @@ impl Pixels {
     }
 
     pub fn is_pointer(&self) -> bool {
-        matches!(self, Pixels::Pointer(_))
+        matches!(self, Pixels::Pointer(_) | Pixels::Pointer16(_))
     }
 
-    pub fn pointer(&self) -> *mut u8 {
+    pub fn ptr(&self) -> *const u8 {
+        match self {
+            Pixels::Pointer(ptr) => *ptr as *const u8,
+            Pixels::Buffer(buffer) => buffer.as_ptr(),
+            _ => std::ptr::null_mut(),
+        }
+    }
+
+    pub fn ptr16(&self) -> *const u16 {
+        match self {
+            Pixels::Pointer16(ptr) => *ptr as *const u16,
+            Pixels::Buffer16(buffer) => buffer.as_ptr(),
+            _ => std::ptr::null_mut(),
+        }
+    }
+
+    pub fn ptr_mut(&mut self) -> *mut u8 {
         match self {
             Pixels::Pointer(ptr) => *ptr,
+            Pixels::Buffer(buffer) => buffer.as_mut_ptr(),
             _ => std::ptr::null_mut(),
+        }
+    }
+
+    pub fn ptr16_mut(&mut self) -> *mut u16 {
+        match self {
+            Pixels::Pointer16(ptr) => *ptr,
+            Pixels::Buffer16(buffer) => buffer.as_mut_ptr(),
+            _ => std::ptr::null_mut(),
+        }
+    }
+
+    pub fn clone_pointer(&self) -> Option<Pixels> {
+        match self {
+            Pixels::Pointer(ptr) => Some(Pixels::Pointer(*ptr)),
+            Pixels::Pointer16(ptr) => Some(Pixels::Pointer16(*ptr)),
+            _ => None,
         }
     }
 
@@ -76,6 +112,7 @@ impl Pixels {
                 let offset = isize_from_usize(offset)?;
                 Ok(unsafe { std::slice::from_raw_parts(ptr.offset(offset), size) })
             }
+            Pixels::Pointer16(_) => Err(AvifError::NoContent),
             Pixels::Buffer(buffer) => {
                 let end = offset.checked_add(size).ok_or(AvifError::NoContent)?;
                 Ok(&buffer[offset..end])
@@ -92,6 +129,7 @@ impl Pixels {
                 let offset = isize_from_usize(offset)?;
                 Ok(unsafe { std::slice::from_raw_parts_mut(ptr.offset(offset), size) })
             }
+            Pixels::Pointer16(_) => Err(AvifError::NoContent),
             Pixels::Buffer(buffer) => {
                 let end = offset.checked_add(size).ok_or(AvifError::NoContent)?;
                 Ok(&mut buffer[offset..end])
@@ -104,7 +142,8 @@ impl Pixels {
         let offset: usize = usize_from_u32(offset)?;
         let size: usize = usize_from_u32(size)?;
         match self {
-            Pixels::Pointer(ptr) => {
+            Pixels::Pointer(_) => Err(AvifError::NoContent),
+            Pixels::Pointer16(ptr) => {
                 let offset = isize_from_usize(offset)?;
                 let ptr = (*ptr) as *const u16;
                 Ok(unsafe { std::slice::from_raw_parts(ptr.offset(offset), size) })
@@ -121,9 +160,10 @@ impl Pixels {
         let offset: usize = usize_from_u32(offset)?;
         let size: usize = usize_from_u32(size)?;
         match self {
-            Pixels::Pointer(ptr) => {
+            Pixels::Pointer(_) => Err(AvifError::NoContent),
+            Pixels::Pointer16(ptr) => {
                 let offset = isize_from_usize(offset)?;
-                let ptr = (*ptr) as *mut u16;
+                let ptr = *ptr;
                 Ok(unsafe { std::slice::from_raw_parts_mut(ptr.offset(offset), size) })
             }
             Pixels::Buffer(_) => Err(AvifError::NoContent),
@@ -131,42 +171,6 @@ impl Pixels {
                 let end = offset.checked_add(size).ok_or(AvifError::NoContent)?;
                 Ok(&mut buffer[offset..end])
             }
-        }
-    }
-
-    pub fn slices(&self, offset: u32, size: u32) -> AvifResult<U8OrU16Slice> {
-        match self {
-            Pixels::Pointer(ptr) => {
-                let offset = isize_from_u32(offset)?;
-                let size = usize_from_u32(size)?;
-                let ptr16 = (*ptr) as *const u16;
-                unsafe {
-                    Ok((
-                        Some(std::slice::from_raw_parts(ptr.offset(offset), size)),
-                        Some(std::slice::from_raw_parts(ptr16.offset(offset), size)),
-                    ))
-                }
-            }
-            Pixels::Buffer(_) => Ok((Some(self.slice(offset, size)?), None)),
-            Pixels::Buffer16(_) => Ok((None, Some(self.slice16(offset, size / 2)?))),
-        }
-    }
-
-    pub fn slices_mut(&mut self, offset: u32, size: u32) -> AvifResult<U8OrU16SliceMut> {
-        match self {
-            Pixels::Pointer(ptr) => {
-                let offset = isize_from_u32(offset)?;
-                let size = usize_from_u32(size)?;
-                let ptr16 = (*ptr) as *mut u16;
-                unsafe {
-                    Ok((
-                        Some(std::slice::from_raw_parts_mut(ptr.offset(offset), size)),
-                        Some(std::slice::from_raw_parts_mut(ptr16.offset(offset), size)),
-                    ))
-                }
-            }
-            Pixels::Buffer(_) => Ok((Some(self.slice_mut(offset, size)?), None)),
-            Pixels::Buffer16(_) => Ok((None, Some(self.slice16_mut(offset, size / 2)?))),
         }
     }
 }

--- a/src/reformat/alpha.rs
+++ b/src/reformat/alpha.rs
@@ -5,7 +5,6 @@ use super::rgb;
 
 use crate::decoder::Category;
 use crate::image::Plane;
-use crate::internal_utils::pixels::*;
 use crate::internal_utils::*;
 use crate::*;
 
@@ -170,7 +169,7 @@ impl image::Image {
                     None,
                     None,
                     None,
-                    Some(Pixels::Pointer(self.planes2[3].as_ref().unwrap().pointer())),
+                    self.planes2[3].as_ref().unwrap().clone_pointer(),
                 ],
                 row_bytes: [0, 0, 0, self.row_bytes[3]],
                 ..image::Image::default()
@@ -216,6 +215,8 @@ impl image::Image {
 mod tests {
     use super::*;
 
+    use crate::internal_utils::pixels::*;
+
     use rand::Rng;
     use test_case::test_matrix;
 
@@ -247,7 +248,11 @@ mod tests {
             buffer.reserve_exact(buffer_size);
             buffer.resize(buffer_size, 0);
             // Use a pointer to mimic C API calls.
-            rgb.pixels = Some(Pixels::Pointer(buffer.as_mut_ptr()));
+            rgb.pixels = Some(if rgb.depth > 8 {
+                Pixels::Pointer16(buffer.as_mut_ptr() as *mut u16)
+            } else {
+                Pixels::Pointer(buffer.as_mut_ptr())
+            });
             rgb.row_bytes = width * 4 * pixel_size;
         } else {
             rgb.allocate()?;

--- a/src/reformat/rgb.rs
+++ b/src/reformat/rgb.rs
@@ -137,45 +137,38 @@ impl Image {
         }
         match self.pixels.as_mut().unwrap() {
             Pixels::Pointer(ptr) => *ptr,
+            Pixels::Pointer16(ptr) => *ptr as *mut u8,
             Pixels::Buffer(buffer) => buffer.as_mut_ptr(),
             Pixels::Buffer16(buffer) => buffer.as_mut_ptr() as *mut u8,
         }
     }
 
     pub fn row(&self, row: u32) -> AvifResult<&[u8]> {
-        match &self.pixels {
-            Some(pixels) => pixels.slice(row * self.row_bytes, self.row_bytes),
-            None => Err(AvifError::NoContent),
-        }
+        self.pixels
+            .as_ref()
+            .ok_or(AvifError::NoContent)?
+            .slice(row * self.row_bytes, self.row_bytes)
     }
 
     pub fn row_mut(&mut self, row: u32) -> AvifResult<&mut [u8]> {
-        match &mut self.pixels {
-            Some(pixels) => pixels.slice_mut(row * self.row_bytes, self.row_bytes),
-            None => Err(AvifError::NoContent),
-        }
+        self.pixels
+            .as_mut()
+            .ok_or(AvifError::NoContent)?
+            .slice_mut(row * self.row_bytes, self.row_bytes)
     }
 
     pub fn row16(&self, row: u32) -> AvifResult<&[u16]> {
-        match &self.pixels {
-            Some(pixels) => pixels.slice16(row * self.row_bytes / 2, self.row_bytes / 2),
-            None => Err(AvifError::NoContent),
-        }
+        self.pixels
+            .as_ref()
+            .ok_or(AvifError::NoContent)?
+            .slice16(row * self.row_bytes / 2, self.row_bytes / 2)
     }
 
     pub fn row16_mut(&mut self, row: u32) -> AvifResult<&mut [u16]> {
-        match &mut self.pixels {
-            Some(pixels) => pixels.slice16_mut(row * self.row_bytes / 2, self.row_bytes / 2),
-            None => Err(AvifError::NoContent),
-        }
-    }
-
-    pub fn rows_mut(&mut self, row: u32) -> AvifResult<U8OrU16SliceMut> {
-        if self.depth == 8 {
-            Ok((Some(self.row_mut(row)?), None))
-        } else {
-            Ok((None, Some(self.row16_mut(row)?)))
-        }
+        self.pixels
+            .as_mut()
+            .ok_or(AvifError::NoContent)?
+            .slice16_mut(row * self.row_bytes / 2, self.row_bytes / 2)
     }
 
     pub fn allocate(&mut self) -> AvifResult<()> {

--- a/src/reformat/rgb_impl.rs
+++ b/src/reformat/rgb_impl.rs
@@ -276,7 +276,6 @@ pub fn yuv_to_rgb_any(
         let a_row = image
             .row_generic(Plane::A, j)
             .ok_or(AvifError::InvalidArgument);
-        let (mut rgb_row, mut rgb_row16) = rgb.rows_mut(j)?;
         for i in 0..image.width as usize {
             let y = unorm_value(y_row?, i, yuv_max_channel, &table_y);
             let mut cb = 0.5;
@@ -367,12 +366,12 @@ pub fn yuv_to_rgb_any(
                 }
             }
             if rgb_depth == 8 {
-                let dst = rgb_row.as_mut().unwrap();
+                let dst = rgb.row_mut(j)?;
                 dst[(i * rgb_channel_count) + r_offset] = (0.5 + (rc * rgb_max_channel_f)) as u8;
                 dst[(i * rgb_channel_count) + g_offset] = (0.5 + (gc * rgb_max_channel_f)) as u8;
                 dst[(i * rgb_channel_count) + b_offset] = (0.5 + (bc * rgb_max_channel_f)) as u8;
             } else {
-                let dst16 = rgb_row16.as_mut().unwrap();
+                let dst16 = rgb.row16_mut(j)?;
                 dst16[(i * rgb_channel_count) + r_offset] = (0.5 + (rc * rgb_max_channel_f)) as u16;
                 dst16[(i * rgb_channel_count) + g_offset] = (0.5 + (gc * rgb_max_channel_f)) as u16;
                 dst16[(i * rgb_channel_count) + b_offset] = (0.5 + (bc * rgb_max_channel_f)) as u16;

--- a/src/utils/raw.rs
+++ b/src/utils/raw.rs
@@ -67,19 +67,19 @@ impl RawWriter {
             return true;
         }
         for plane in ALL_PLANES {
-            let avif_plane = image.plane(plane);
-            if avif_plane.is_none() {
+            let plane_data = image.plane_data(plane);
+            if plane_data.is_none() {
                 continue;
             }
-            let avif_plane = avif_plane.unwrap();
-            let byte_count: usize = (avif_plane.width * avif_plane.pixel_size)
-                .try_into()
-                .unwrap();
-            for y in 0..avif_plane.height {
-                let stride_offset: usize = (y * avif_plane.row_bytes).try_into().unwrap();
-                //println!("{y}: {stride_offset} plane_height: {}", avif_plane.height);
-                let pixels = &avif_plane.data.unwrap()[stride_offset..stride_offset + byte_count];
-                if self.file.as_ref().unwrap().write_all(pixels).is_err() {
+            let plane_data = plane_data.unwrap();
+            for y in 0..plane_data.height {
+                // TODO: Handle row16.
+                let row = if let Ok(row) = image.row(plane, y) {
+                    row
+                } else {
+                    return false;
+                };
+                if self.file.as_ref().unwrap().write_all(row).is_err() {
                     return false;
                 }
             }

--- a/tests/decoder_tests.rs
+++ b/tests/decoder_tests.rs
@@ -49,7 +49,7 @@ fn alpha_no_ispe() {
     let res = decoder.next_image();
     assert!(res.is_ok());
     let image = decoder.image();
-    let alpha_plane = image.plane(Plane::A);
+    let alpha_plane = image.plane_data(Plane::A);
     assert!(alpha_plane.is_some());
     assert!(alpha_plane.unwrap().row_bytes > 0);
 }
@@ -108,7 +108,7 @@ fn color_grid_alpha_no_grid() {
     let res = decoder.next_image();
     assert!(res.is_ok());
     let image = decoder.image();
-    let alpha_plane = image.plane(Plane::A);
+    let alpha_plane = image.plane_data(Plane::A);
     assert!(alpha_plane.is_some());
     assert!(alpha_plane.unwrap().row_bytes > 0);
 }


### PR DESCRIPTION
This is a large scale re-write that does the following:
1) Ensure there are only two ways to access pixel data (as a plane
   pointer or as a row reference).
2) Get rid of the intermediate optional slice types and use
   specific row* functions in each caller.
