### PR TITLE
Add IO::read_exact()

### DIFF
--- a/src/decoder/item.rs
+++ b/src/decoder/item.rs
@@ -43,7 +43,7 @@ impl Item {
     pub fn stream<'a>(&'a self, io: &'a mut GenericIO) -> AvifResult<IStream> {
         // TODO: handle multiple extents.
         let io_data = match self.idat.is_empty() {
-            true => io.read(self.data_offset(), self.size)?,
+            true => io.read_exact(self.data_offset(), self.size)?,
             false => {
                 // TODO: assumes idat offset is 0.
                 self.idat.as_slice()

--- a/src/internal_utils/io.rs
+++ b/src/internal_utils/io.rs
@@ -23,13 +23,14 @@ impl DecoderFileIO {
 }
 
 impl decoder::IO for DecoderFileIO {
-    fn read(&mut self, offset: u64, size: usize) -> AvifResult<&[u8]> {
+    fn read(&mut self, offset: u64, max_read_size: usize) -> AvifResult<&[u8]> {
         let file_size = self.size_hint();
         if offset > file_size {
             return Err(AvifError::IoError);
         }
         let available_size: usize = (file_size - offset) as usize;
-        let size_to_read: usize = if size > available_size { available_size } else { size };
+        let size_to_read: usize =
+            if max_read_size > available_size { available_size } else { max_read_size };
         if size_to_read > 0 {
             if self.buffer.capacity() < size_to_read
                 && self.buffer.try_reserve_exact(size_to_read).is_err()
@@ -77,13 +78,14 @@ impl DecoderRawIO<'_> {
 }
 
 impl decoder::IO for DecoderRawIO<'_> {
-    fn read(&mut self, offset: u64, size: usize) -> AvifResult<&[u8]> {
+    fn read(&mut self, offset: u64, max_read_size: usize) -> AvifResult<&[u8]> {
         let data_len = self.data.len() as u64;
         if offset > data_len {
             return Err(AvifError::IoError);
         }
         let available_size: usize = (data_len - offset) as usize;
-        let size_to_read: usize = if size > available_size { available_size } else { size };
+        let size_to_read: usize =
+            if max_read_size > available_size { available_size } else { max_read_size };
         let slice_start = usize_from_u64(offset)?;
         let slice_end = slice_start + size_to_read;
         Ok(&self.data[slice_start..slice_end])

--- a/src/parser/mp4box.rs
+++ b/src/parser/mp4box.rs
@@ -1232,10 +1232,7 @@ pub fn parse(io: &mut GenericIO) -> AvifResult<AvifBoxes> {
         // Read the rest of the box if necessary.
         match header.box_type.as_str() {
             "ftyp" | "meta" | "moov" => {
-                let box_data = io.read(parse_offset, header.size)?;
-                if box_data.len() != header.size {
-                    return Err(AvifError::TruncatedData);
-                }
+                let box_data = io.read_exact(parse_offset, header.size)?;
                 let mut box_stream = IStream::create(box_data);
                 match header.box_type.as_str() {
                     "ftyp" => {

--- a/tests/decoder_tests.rs
+++ b/tests/decoder_tests.rs
@@ -359,14 +359,14 @@ struct CustomIO {
 }
 
 impl decoder::IO for CustomIO {
-    fn read(&mut self, offset: u64, size: usize) -> AvifResult<&[u8]> {
+    fn read(&mut self, offset: u64, max_read_size: usize) -> AvifResult<&[u8]> {
         let available_size = self.available_size_rc.borrow();
         let start = usize::try_from(offset).unwrap();
-        let end = start + size;
+        let end = start + max_read_size;
         if start > self.data.len() || end > self.data.len() {
             return Err(AvifError::IoError);
         }
-        let mut ssize = size;
+        let mut ssize = max_read_size;
         if ssize > self.data.len() - start {
             ssize = self.data.len() - start;
         }


### PR DESCRIPTION
Also rename IO::read() arg to max_read_size which is closer to the behavior.