### PR TITLE
Refactor find_nclx and find_icc

### DIFF
--- a/src/parser/mp4box.rs
+++ b/src/parser/mp4box.rs
@@ -70,7 +70,7 @@ pub struct PixelInformation {
     pub plane_depths: [u8; MAX_PLANE_COUNT],
 }
 
-#[derive(Debug, Default, Clone, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct CodecConfiguration {
     pub seq_profile: u8,
     pub seq_level_idx0: u8,


### PR DESCRIPTION
Use a loop instead of iter() to avoid repeating the matching enum value.
Replace find_xxxx() macro by find_map() at the calling sites.