### PR TITLE
Move reinterpret_f32_as_u32() from mod to rgb

### DIFF
--- a/src/internal_utils/mod.rs
+++ b/src/internal_utils/mod.rs
@@ -206,7 +206,6 @@ find_property_function!(find_irot_angle, ImageRotation, u8);
 find_property_function!(find_imir_axis, ImageMirror, u8);
 
 pub fn check_limits(width: u32, height: u32, size_limit: u32, dimension_limit: u32) -> bool {
-    //println!("w: {width} h: {height} s: {size_limit} d: {dimension_limit}");
     if height == 0 {
         return false;
     }
@@ -243,10 +242,6 @@ pub fn create_vec_exact<T>(size: usize) -> AvifResult<Vec<T>> {
         return Err(AvifError::OutOfMemory);
     }
     Ok(v)
-}
-
-pub fn reinterpret_f32_as_u32(f: f32) -> u32 {
-    u32::from_be_bytes(f.to_be_bytes())
 }
 
 #[cfg(test)]

--- a/src/reformat/rgb.rs
+++ b/src/reformat/rgb.rs
@@ -237,6 +237,7 @@ impl Image {
         }
         // This constant comes from libyuv. For details, see here:
         // https://chromium.googlesource.com/libyuv/libyuv/+/2f87e9a7/source/row_common.cc#3537
+        let reinterpret_f32_as_u32 = |f: f32| u32::from_le_bytes(f.to_le_bytes());
         let multiplier = 1.925_93e-34 * scale;
         for y in 0..self.height {
             let row = self.row16_mut(y)?;


### PR DESCRIPTION
Also use little endians as most platforms use that in memory. Also remove dubg print in check_limits().