### PR TITLE
Use a Vec<u8> in PixelInformation instead of count

### DIFF
--- a/src/decoder/item.rs
+++ b/src/decoder/item.rs
@@ -173,8 +173,8 @@ impl Item {
         }
         match self.pixi() {
             Some(pixi) => {
-                for i in 0..pixi.plane_count as usize {
-                    if pixi.plane_depths[i] != av1C.depth() {
+                for depth in &pixi.plane_depths {
+                    if *depth != av1C.depth() {
                         println!("pixi depth does not match av1C depth");
                         return Err(AvifError::BmffParseFailed);
                     }

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -436,11 +436,7 @@ impl Decoder {
             self.gainmap.alt_clli = *clli;
         }
         if let Some(pixi) = tonemap_item.pixi() {
-            if pixi.plane_count == 0 {
-                println!("invalid plane count in tonemap");
-                return Err(AvifError::BmffParseFailed);
-            }
-            self.gainmap.alt_plane_count = pixi.plane_count;
+            self.gainmap.alt_plane_count = pixi.plane_depths.len() as u8;
             self.gainmap.alt_plane_depth = pixi.plane_depths[0];
         }
         Ok(())

--- a/src/parser/mp4box.rs
+++ b/src/parser/mp4box.rs
@@ -73,8 +73,7 @@ pub struct ImageSpatialExtents {
 
 #[derive(Debug, Default, Clone)]
 pub struct PixelInformation {
-    pub plane_count: u8,
-    pub plane_depths: [u8; MAX_PLANE_COUNT],
+    pub plane_depths: Vec<u8>,
 }
 
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
@@ -384,18 +383,22 @@ fn parse_ispe(stream: &mut IStream) -> AvifResult<ItemProperty> {
 fn parse_pixi(stream: &mut IStream) -> AvifResult<ItemProperty> {
     // Section 6.5.6.2 of ISO/IEC 23008-12.
     let (_version, _flags) = stream.read_and_enforce_version_and_flags(0)?;
-    let mut pixi = PixelInformation {
-        // unsigned int (8) num_channels;
-        plane_count: stream.read_u8()?,
-        ..PixelInformation::default()
-    };
-    if usize::from(pixi.plane_count) > MAX_PLANE_COUNT {
-        println!("Invalid plane count in pixi box");
+    // unsigned int (8) num_channels;
+    let num_channels = stream.read_u8()? as usize;
+    if num_channels == 0 || num_channels > MAX_PLANE_COUNT {
+        println!("Invalid plane count {num_channels} in pixi box");
         return Err(AvifError::BmffParseFailed);
     }
-    for i in 0..pixi.plane_count {
+    let mut pixi = PixelInformation {
+        plane_depths: create_vec_exact(num_channels)?,
+    };
+    for _ in 0..num_channels {
         // unsigned int (8) bits_per_channel;
-        pixi.plane_depths[i as usize] = stream.read_u8()?;
+        pixi.plane_depths.push(stream.read_u8()?);
+        if pixi.plane_depths.last().unwrap() != pixi.plane_depths.first().unwrap() {
+            println!("unsupported mismatched plane depths in pixi box");
+            return Err(AvifError::UnsupportedDepth);
+        }
     }
     Ok(ItemProperty::PixelInformation(pixi))
 }


### PR DESCRIPTION
Provides runtime checks for accessing out-of-range values.  
Also sync with https://github.com/AOMediaCodec/libavif/pull/2058.