### PR TITLE
Remove idat check in parse_meta()

### DIFF
--- a/src/parser/mp4box.rs
+++ b/src/parser/mp4box.rs
@@ -896,13 +896,7 @@ fn parse_meta(stream: &mut IStream) -> AvifResult<MetaBox> {
             "iprp" => meta.iprp = parse_iprp(&mut sub_stream)?,
             "iinf" => meta.iinf = parse_iinf(&mut sub_stream)?,
             "iref" => meta.iref = parse_iref(&mut sub_stream)?,
-            "idat" => {
-                if !meta.idat.is_empty() {
-                    println!("meta contains multiple idat boxes");
-                    return Err(AvifError::BmffParseFailed);
-                }
-                meta.idat = parse_idat(&mut sub_stream)?;
-            }
+            "idat" => meta.idat = parse_idat(&mut sub_stream)?,
             _ => {}
         }
     }


### PR DESCRIPTION
It is already checked at line 884.