### PR TITLE
Use same find_property macro in item as mod

### DIFF
--- a/src/decoder/tile.rs
+++ b/src/decoder/tile.rs
@@ -147,7 +147,7 @@ impl Tile {
         let has_lsel;
         match item.lsel() {
             Some(x) => {
-                lsel = x;
+                lsel = *x;
                 has_lsel = true;
             }
             None => {


### PR DESCRIPTION
Cannot deref value in macro because of PixelInformation which cannot have the Copy trait.