### PR TITLE
Use getters instead of Decoder pub fields

### DIFF
--- a/examples/dec.rs
+++ b/examples/dec.rs
@@ -50,14 +50,17 @@ fn main() {
         let _image = decoder.image();
 
         println!("\n^^^ decoder public properties ^^^");
-        println!("image_count: {}", decoder.image_count);
-        println!("timescale: {}", decoder.timescale);
-        println!("duration_in_timescales: {}", decoder.duration_in_timescales);
-        println!("duration: {}", decoder.duration);
-        println!("repetition_count: {:#?}", decoder.repetition_count);
+        println!("image_count: {}", decoder.image_count());
+        println!("timescale: {}", decoder.timescale());
+        println!(
+            "duration_in_timescales: {}",
+            decoder.duration_in_timescales()
+        );
+        println!("duration: {}", decoder.duration());
+        println!("repetition_count: {:#?}", decoder.repetition_count());
         println!("$$$ end decoder public properties $$$\n");
 
-        image_count = decoder.image_count;
+        image_count = decoder.image_count();
         //image_count = 1;
         let mut writer: crabby_avif::utils::y4m::Y4MWriter = Default::default();
         //let mut writer: crabby_avif::utils::raw::RawWriter = Default::default();
@@ -76,7 +79,7 @@ fn main() {
                 println!("error writing y4m file");
                 std::process::exit(1);
             }
-            println!("timing: {:#?}", decoder.image_timing);
+            println!("timing: {:#?}", decoder.image_timing());
         }
         println!("wrote {} frames into {}", image_count, args[2]);
     }

--- a/src/capi/decoder.rs
+++ b/src/capi/decoder.rs
@@ -192,19 +192,19 @@ fn rust_decoder_to_avifDecoder(src: &Decoder, dst: &mut avifDecoder) {
     dst.imageSequenceTrackPresent = to_avifBool(image.image_sequence_track_present);
     dst.progressiveState = image.progressive_state;
 
-    dst.imageTiming = src.image_timing;
-    dst.imageCount = src.image_count as i32;
-    dst.imageIndex = src.image_index as i32;
-    dst.repetitionCount = match src.repetition_count {
+    dst.imageTiming = src.image_timing();
+    dst.imageCount = src.image_count() as i32;
+    dst.imageIndex = src.image_index() as i32;
+    dst.repetitionCount = match src.repetition_count() {
         RepetitionCount::Unknown => AVIF_REPETITION_COUNT_UNKNOWN,
         RepetitionCount::Infinite => AVIF_REPETITION_COUNT_INFINITE,
         RepetitionCount::Finite(x) => x,
     };
 
-    if src.gainmap_present {
+    if src.gainmap_present() {
         dst.gainMapPresent = AVIF_TRUE;
-        dst.gainmap_image_object = (&src.gainmap.image).into();
-        dst.gainmap_object = (&src.gainmap).into();
+        dst.gainmap_image_object = (&src.gainmap().image).into();
+        dst.gainmap_object = src.gainmap().into();
         dst.gainmap_object.image = (&mut dst.gainmap_image_object) as *mut avifImage;
         dst.image_object.gainMap = (&mut dst.gainmap_object) as *mut avifGainMap;
     }
@@ -266,7 +266,7 @@ pub unsafe extern "C" fn crabby_avifDecoderNthImage(
         rust_decoder.settings = (&(*decoder)).into();
 
         let previous_decoded_row_count = rust_decoder.decoded_row_count();
-        let image_index = (rust_decoder.image_index + 1) as u32;
+        let image_index = (rust_decoder.image_index() + 1) as u32;
 
         let res = rust_decoder.nth_image(frameIndex);
         let mut early_return = false;
@@ -393,6 +393,7 @@ pub unsafe extern "C" fn crabby_avifDecoderDecodedRowCount(decoder: *const avifD
     rust_decoder.decoded_row_count()
 }
 
+#[allow(non_camel_case_types)]
 pub type avifExtent = Extent;
 
 #[no_mangle]

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -240,15 +240,15 @@ enum ParseState {
 #[derive(Default)]
 pub struct Decoder {
     pub settings: Settings,
-    pub image_count: u32,
-    pub image_index: i32,
-    pub image_timing: ImageTiming,
-    pub timescale: u64,
-    pub duration_in_timescales: u64,
-    pub duration: f64,
-    pub repetition_count: RepetitionCount,
-    pub gainmap: GainMap,
-    pub gainmap_present: bool,
+    image_count: u32,
+    image_index: i32,
+    image_timing: ImageTiming,
+    timescale: u64,
+    duration_in_timescales: u64,
+    duration: f64,
+    repetition_count: RepetitionCount,
+    gainmap: GainMap,
+    gainmap_present: bool,
     image: Image,
     source: Source,
     tile_info: [TileInfo; 3],
@@ -293,6 +293,34 @@ impl Category {
 }
 
 impl Decoder {
+    pub fn image_count(&self) -> u32 {
+        self.image_count
+    }
+    pub fn image_index(&self) -> i32 {
+        self.image_index
+    }
+    pub fn image_timing(&self) -> ImageTiming {
+        self.image_timing
+    }
+    pub fn timescale(&self) -> u64 {
+        self.timescale
+    }
+    pub fn duration_in_timescales(&self) -> u64 {
+        self.duration_in_timescales
+    }
+    pub fn duration(&self) -> f64 {
+        self.duration
+    }
+    pub fn repetition_count(&self) -> RepetitionCount {
+        self.repetition_count
+    }
+    pub fn gainmap(&self) -> &GainMap {
+        &self.gainmap
+    }
+    pub fn gainmap_present(&self) -> bool {
+        self.gainmap_present
+    }
+
     fn parsing_complete(&self) -> bool {
         self.parse_state == ParseState::Complete
     }

--- a/src/decoder/track.rs
+++ b/src/decoder/track.rs
@@ -3,7 +3,7 @@ use crate::parser::mp4box::ItemProperty;
 use crate::parser::mp4box::MetaBox;
 use crate::*;
 
-#[derive(Debug, Default)]
+#[derive(Clone, Copy, Debug, Default)]
 pub enum RepetitionCount {
     #[default]
     Unknown,

--- a/tests/decoder_tests.rs
+++ b/tests/decoder_tests.rs
@@ -77,9 +77,9 @@ fn animated_image() {
     let image = decoder.image();
     assert!(!image.alpha_present);
     assert!(image.image_sequence_track_present);
-    assert_eq!(decoder.image_count, 5);
+    assert_eq!(decoder.image_count(), 5);
     assert!(matches!(
-        decoder.repetition_count,
+        decoder.repetition_count(),
         RepetitionCount::Finite(0)
     ));
     if !HAS_DECODER {
@@ -103,8 +103,11 @@ fn animated_image_with_source_set_to_primary_item() {
     assert!(image.image_sequence_track_present);
     // imageCount is expected to be 1 because we are using primary item as the
     // preferred source.
-    assert_eq!(decoder.image_count, 1);
-    assert!(matches!(decoder.repetition_count, RepetitionCount::Unknown));
+    assert_eq!(decoder.image_count(), 1);
+    assert!(matches!(
+        decoder.repetition_count(),
+        RepetitionCount::Unknown
+    ));
     if !HAS_DECODER {
         return;
     }
@@ -167,11 +170,11 @@ fn progressive(filename: &str, layer_count: u32, width: u32, height: u32) {
     ));
     assert_eq!(image.width, width);
     assert_eq!(image.height, height);
-    assert_eq!(decoder.image_count, layer_count);
+    assert_eq!(decoder.image_count(), layer_count);
     if !HAS_DECODER {
         return;
     }
-    for _i in 0..decoder.image_count {
+    for _i in 0..decoder.image_count() {
         let res = decoder.next_image();
         assert!(res.is_ok());
         let image = decoder.image();
@@ -234,12 +237,12 @@ fn color_grid_gainmap_different_grid() {
     assert_eq!(image.height, 200 * 3);
     assert_eq!(image.depth, 10);
     // Gain map: 2x2 grid of 64x80 tiles.
-    assert!(decoder.gainmap_present);
-    assert_eq!(decoder.gainmap.image.width, 64 * 2);
-    assert_eq!(decoder.gainmap.image.height, 80 * 2);
-    assert_eq!(decoder.gainmap.image.depth, 8);
-    assert_eq!(decoder.gainmap.metadata.alternate_hdr_headroom.0, 6);
-    assert_eq!(decoder.gainmap.metadata.alternate_hdr_headroom.1, 2);
+    assert!(decoder.gainmap_present());
+    assert_eq!(decoder.gainmap().image.width, 64 * 2);
+    assert_eq!(decoder.gainmap().image.height, 80 * 2);
+    assert_eq!(decoder.gainmap().image.depth, 8);
+    assert_eq!(decoder.gainmap().metadata.alternate_hdr_headroom.0, 6);
+    assert_eq!(decoder.gainmap().metadata.alternate_hdr_headroom.1, 2);
     if !HAS_DECODER {
         return;
     }
@@ -261,12 +264,12 @@ fn color_grid_alpha_grid_gainmap_nogrid() {
     assert_eq!(image.height, 200 * 3);
     assert_eq!(image.depth, 10);
     // Gain map: single image of size 64x80.
-    assert!(decoder.gainmap_present);
-    assert_eq!(decoder.gainmap.image.width, 64);
-    assert_eq!(decoder.gainmap.image.height, 80);
-    assert_eq!(decoder.gainmap.image.depth, 8);
-    assert_eq!(decoder.gainmap.metadata.alternate_hdr_headroom.0, 6);
-    assert_eq!(decoder.gainmap.metadata.alternate_hdr_headroom.1, 2);
+    assert!(decoder.gainmap_present());
+    assert_eq!(decoder.gainmap().image.width, 64);
+    assert_eq!(decoder.gainmap().image.height, 80);
+    assert_eq!(decoder.gainmap().image.depth, 8);
+    assert_eq!(decoder.gainmap().metadata.alternate_hdr_headroom.0, 6);
+    assert_eq!(decoder.gainmap().metadata.alternate_hdr_headroom.1, 2);
     if !HAS_DECODER {
         return;
     }
@@ -288,12 +291,12 @@ fn color_nogrid_alpha_nogrid_gainmap_grid() {
     assert_eq!(image.height, 200);
     assert_eq!(image.depth, 10);
     // Gain map: 2x2 grid of 64x80 tiles.
-    assert!(decoder.gainmap_present);
-    assert_eq!(decoder.gainmap.image.width, 64 * 2);
-    assert_eq!(decoder.gainmap.image.height, 80 * 2);
-    assert_eq!(decoder.gainmap.image.depth, 8);
-    assert_eq!(decoder.gainmap.metadata.alternate_hdr_headroom.0, 6);
-    assert_eq!(decoder.gainmap.metadata.alternate_hdr_headroom.1, 2);
+    assert!(decoder.gainmap_present());
+    assert_eq!(decoder.gainmap().image.width, 64 * 2);
+    assert_eq!(decoder.gainmap().image.height, 80 * 2);
+    assert_eq!(decoder.gainmap().image.depth, 8);
+    assert_eq!(decoder.gainmap().metadata.alternate_hdr_headroom.0, 6);
+    assert_eq!(decoder.gainmap().metadata.alternate_hdr_headroom.1, 2);
     if !HAS_DECODER {
         return;
     }
@@ -337,7 +340,7 @@ fn raw_io() {
         .set_io_raw(data.as_ptr(), data.len())
         .expect("Failed to set IO");
     assert!(decoder.parse().is_ok());
-    assert_eq!(decoder.image_count, 5);
+    assert_eq!(decoder.image_count(), 5);
     if !HAS_DECODER {
         return;
     }
@@ -391,7 +394,7 @@ fn custom_io() {
     });
     decoder.set_io(io);
     assert!(decoder.parse().is_ok());
-    assert_eq!(decoder.image_count, 5);
+    assert_eq!(decoder.image_count(), 5);
     if !HAS_DECODER {
         return;
     }
@@ -552,7 +555,7 @@ fn nth_image() {
     let mut decoder = get_decoder("colors-animated-8bpc.avif");
     let res = decoder.parse();
     assert!(res.is_ok());
-    assert_eq!(decoder.image_count, 5);
+    assert_eq!(decoder.image_count(), 5);
     if !HAS_DECODER {
         return;
     }


### PR DESCRIPTION
Makes sure the user does not modify fields they are not supposed to.
Not sure if worth the change though.