### PR TITLE
Use Options for Track::aux_for_id and prem_by_id

### DIFF
--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -733,7 +733,7 @@ impl Decoder {
                     )?);
                     self.tile_info[Category::Alpha.usize()].tile_count = 1;
                     self.image.alpha_present = true;
-                    self.image.alpha_premultiplied = color_track.prem_by_id == alpha_track.id;
+                    self.image.alpha_premultiplied = color_track.prem_by_id == Some(alpha_track.id);
                 }
 
                 self.image_index = -1;

--- a/src/parser/mp4box.rs
+++ b/src/parser/mp4box.rs
@@ -1410,12 +1410,12 @@ fn parse_tref(stream: &mut IStream, track: &mut Track) -> AvifResult<()> {
             "auxl" => {
                 // unsigned int(32) track_IDs[];
                 // Use only the first one and skip the rest.
-                track.aux_for_id = sub_stream.read_u32()?;
+                track.aux_for_id = Some(sub_stream.read_u32()?);
             }
             "prem" => {
                 // unsigned int(32) track_IDs[];
                 // Use only the first one and skip the rest.
-                track.prem_by_id = sub_stream.read_u32()?;
+                track.prem_by_id = Some(sub_stream.read_u32()?);
             }
             _ => {}
         }


### PR DESCRIPTION
Avoids having is_color() return true if track_ID 0 was read in parse_tref().