### PR TITLE
Remove backward direction parameter

### DIFF
--- a/include/avif/avif.h
+++ b/include/avif/avif.h
@@ -314,7 +314,6 @@ struct avifGainMapMetadata {
     uint32_t baseHdrHeadroomD;
     uint32_t alternateHdrHeadroomN;
     uint32_t alternateHdrHeadroomD;
-    avifBool backwardDirection;
     avifBool useBaseColorSpace;
 };
 

--- a/src/capi/gainmap.rs
+++ b/src/capi/gainmap.rs
@@ -40,7 +40,6 @@ pub struct avifGainMapMetadata {
     pub baseHdrHeadroomD: u32,
     pub alternateHdrHeadroomN: u32,
     pub alternateHdrHeadroomD: u32,
-    pub backwardDirection: avifBool,
     pub useBaseColorSpace: avifBool,
 }
 
@@ -69,7 +68,6 @@ impl From<&GainMapMetadata> for avifGainMapMetadata {
             baseHdrHeadroomD: m.base_hdr_headroom.1,
             alternateHdrHeadroomN: m.alternate_hdr_headroom.0,
             alternateHdrHeadroomD: m.alternate_hdr_headroom.1,
-            backwardDirection: m.backward_direction as avifBool,
             useBaseColorSpace: m.use_base_color_space as avifBool,
         }
     }

--- a/src/decoder/gainmap.rs
+++ b/src/decoder/gainmap.rs
@@ -27,7 +27,6 @@ pub struct GainMapMetadata {
     pub alternate_offset: [Fraction; 3],
     pub base_hdr_headroom: UFraction,
     pub alternate_hdr_headroom: UFraction,
-    pub backward_direction: bool,
     pub use_base_color_space: bool,
 }
 

--- a/src/parser/mp4box.rs
+++ b/src/parser/mp4box.rs
@@ -1728,7 +1728,6 @@ pub fn parse_tmap(stream: &mut IStream) -> AvifResult<GainMapMetadata> {
     let channel_count: usize = ((flags & 1) * 2 + 1).into();
     let mut metadata = GainMapMetadata {
         use_base_color_space: (flags & 2) != 0,
-        backward_direction: (flags & 4) != 0,
         ..GainMapMetadata::default()
     };
     let use_common_denominator = (flags & 8) != 0;


### PR DESCRIPTION
This parameter is no longer in the ISO 21496-1 specification.