### PR TITLE
Quiet warning when not using ndk-sys dependency

### DIFF
--- a/sys/ndk-sys/build.rs
+++ b/sys/ndk-sys/build.rs
@@ -27,7 +27,17 @@ fn main() {
 
     let build_target = std::env::var("TARGET").unwrap();
     if !build_target.contains("android") {
-        panic!("Not an android target: {build_target}");
+        println!("cargo::warning=Not an android target: {build_target}");
+        // Define CRABBYAVIF_ANDROID_NDK_MEDIA_BINDINGS_RS to avoid src/lib.rs
+        // complaining about either undefined env!() or non-literal string.
+        // Point to an empty file as a no-op.
+        println!(
+            "cargo:rustc-env=CRABBYAVIF_ANDROID_NDK_MEDIA_BINDINGS_RS={}",
+            PathBuf::from(&PathBuf::from(env!("CARGO_MANIFEST_DIR")))
+                .join(path_buf(&["src", "empty.rs"]))
+                .display()
+        );
+        return;
     };
 
     // Generate bindings.
@@ -37,7 +47,7 @@ fn main() {
     let host_tag = "linux-x86_64"; // TODO: Support windows and mac.
     let sysroot = format!(
         "{}/toolchains/llvm/prebuilt/{}/sysroot/",
-        env!("ANDROID_NDK_ROOT"),
+        option_env!("ANDROID_NDK_ROOT").unwrap(),
         host_tag
     );
     let mut bindings = bindgen::Builder::default()

--- a/sys/ndk-sys/src/empty.rs
+++ b/sys/ndk-sys/src/empty.rs
@@ -1,0 +1,15 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Empty file on purpose. See ../build.rs.


### PR DESCRIPTION
Replace panic with cargo::warning in sys/ndk-sys/build.rs.
Replace env!() with option_env!() in sys/ndk-sys/build.rs.
Define CRABBYAVIF_ANDROID_NDK_MEDIA_BINDINGS_RS to no-op empty file to avoid rust-analyzer complaining about a missing include or env.

This avoids errors when opening a local clone of CrabbyAvif in VSCode with no installed Android SDK.  
Feel free to suggest a better approach.