### PR TITLE
Elide some lifetimes in image and stream

### DIFF
--- a/src/image.rs
+++ b/src/image.rs
@@ -313,7 +313,7 @@ impl Image {
         Ok(&mut self.row16_mut(plane, row)?[0..width])
     }
 
-    pub(crate) fn row_generic<'a>(&'a self, plane: Plane, row: u32) -> AvifResult<PlaneRow<'a>> {
+    pub(crate) fn row_generic(&self, plane: Plane, row: u32) -> AvifResult<PlaneRow<'_>> {
         Ok(if self.depth == 8 {
             PlaneRow::Depth8(self.row(plane, row)?)
         } else {

--- a/src/internal_utils/stream.rs
+++ b/src/internal_utils/stream.rs
@@ -80,7 +80,7 @@ pub struct IStream<'a> {
 }
 
 impl IStream<'_> {
-    pub(crate) fn create<'a>(data: &'a [u8]) -> IStream<'a> {
+    pub(crate) fn create(data: &[u8]) -> IStream<'_> {
         IStream { data, offset: 0 }
     }
 
@@ -109,7 +109,7 @@ impl IStream<'_> {
         })
     }
 
-    pub(crate) fn sub_bit_stream<'a>(&'a mut self, size: usize) -> AvifResult<IBitStream<'a>> {
+    pub(crate) fn sub_bit_stream(&mut self, size: usize) -> AvifResult<IBitStream<'_>> {
         self.check(size)?;
         let offset = self.offset;
         checked_incr!(self.offset, size);


### PR DESCRIPTION
From:
cargo clippy --no-default-features --fix