### PR TITLE
Add build folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.DS_Store
 /.vscode
+/build
 /Cargo.lock
 /c_api_tests/build
 /c_build


### PR DESCRIPTION
build/ seems to be created by VSCode when selecting the CMakeLists.txt configuration file used for the C API.