### PR TITLE
Fix clippy warnings in decoder module

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -21,6 +21,7 @@ jobs:
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
     - uses: ./.github/actions/setup-deps
+    - run: cargo clippy --version
     - run: cargo clippy --no-default-features
     - run: cargo clippy --no-default-features --features=capi
     - run: cargo clippy

--- a/src/codecs/dav1d.rs
+++ b/src/codecs/dav1d.rs
@@ -404,7 +404,7 @@ impl Decoder for Dav1d {
         }
         self.flush()?;
         if next_picture.is_some() {
-            self.picture = Some(next_picture.unwrap());
+            self.picture = next_picture;
         } else if category == Category::Alpha && self.picture.is_some() {
             // Special case for alpha, re-use last frame.
         } else {

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -831,17 +831,21 @@ impl Decoder {
         if item.is_grid_item() || item.is_overlay_item() {
             // For grid and overlay items, adopt the icc color profile and the nclx of the first
             // tile if it is not explicitly specified for the overall grid.
-            if first_icc.is_some() && find_icc(&item.properties)?.is_none() {
-                item.properties
-                    .push(ItemProperty::ColorInformation(ColorInformation::Icc(
-                        first_icc.unwrap(),
-                    )));
+            if let Some(first_icc) = first_icc {
+                if find_icc(&item.properties)?.is_none() {
+                    item.properties
+                        .push(ItemProperty::ColorInformation(ColorInformation::Icc(
+                            first_icc,
+                        )));
+                }
             }
-            if first_nclx.is_some() && find_nclx(&item.properties)?.is_none() {
-                item.properties
-                    .push(ItemProperty::ColorInformation(ColorInformation::Nclx(
-                        first_nclx.unwrap(),
-                    )));
+            if let Some(first_nclx) = first_nclx {
+                if find_nclx(&item.properties)?.is_none() {
+                    item.properties
+                        .push(ItemProperty::ColorInformation(ColorInformation::Nclx(
+                            first_nclx,
+                        )));
+                }
             }
         }
         Ok(())

--- a/src/encoder/mod.rs
+++ b/src/encoder/mod.rs
@@ -443,9 +443,9 @@ impl Encoder {
             };
             Self::validate_image_grid(&grid, cell_images)?;
             self.image_metadata = first_image.shallow_clone();
-            if gainmaps.is_some() {
-                self.gainmap_image_metadata = gainmaps.unwrap()[0].image.shallow_clone();
-                self.copy_alt_image_metadata(gainmaps.unwrap()[0], &grid);
+            if let Some(gainmaps) = gainmaps {
+                self.gainmap_image_metadata = gainmaps[0].image.shallow_clone();
+                self.copy_alt_image_metadata(gainmaps[0], &grid);
             }
             let color_item_id = self.add_items(&grid, Category::Color)?;
             self.primary_item_id = color_item_id;


### PR DESCRIPTION
Also print clippy version in the CI.

See failure that happened with https://github.com/webmproject/CrabbyAvif/pull/647 but is unrelated to the change.