### PR TITLE
Replace or(AvifError) by map_err(AvifError)

### DIFF
--- a/src/internal_utils/io.rs
+++ b/src/internal_utils/io.rs
@@ -27,7 +27,7 @@ pub struct DecoderFileIO {
 
 impl DecoderFileIO {
     pub fn create(filename: &String) -> AvifResult<DecoderFileIO> {
-        let file = File::open(filename).or(AvifError::io_error())?;
+        let file = File::open(filename).map_err(AvifError::map_io_error)?;
         Ok(DecoderFileIO {
             file: Some(file),
             buffer: Vec::new(),

--- a/src/internal_utils/mod.rs
+++ b/src/internal_utils/mod.rs
@@ -25,7 +25,7 @@ use std::ops::Range;
 macro_rules! conversion_function {
     ($func:ident, $to: ident, $from:ty) => {
         pub(crate) fn $func(value: $from) -> AvifResult<$to> {
-            $to::try_from(value).or(AvifError::bmff_parse_failed(""))
+            $to::try_from(value).map_err(AvifError::map_unknown_error)
         }
     };
 }

--- a/src/internal_utils/stream.rs
+++ b/src/internal_utils/stream.rs
@@ -331,7 +331,9 @@ impl OStream {
     }
 
     pub(crate) fn try_reserve(&mut self, size: usize) -> AvifResult<()> {
-        self.data.try_reserve(size).or(AvifError::out_of_memory())
+        self.data
+            .try_reserve(size)
+            .map_err(AvifError::map_out_of_memory)
     }
 
     pub(crate) fn write_bits(&mut self, value: u32, num_bits: u8) -> AvifResult<()> {

--- a/src/parser/exif.rs
+++ b/src/parser/exif.rs
@@ -22,7 +22,9 @@ pub(crate) fn parse_exif_tiff_header_offset(stream: &mut IStream) -> AvifResult<
     let mut expected_offset: u32 = 0;
     let mut size = u32::try_from(stream.bytes_left()?).unwrap_or(u32::MAX);
     while size > 0 {
-        let value = stream.read_u32().or(AvifError::invalid_exif_payload())?;
+        let value = stream
+            .read_u32()
+            .map_err(AvifError::map_invalid_exif_payload)?;
         if value == TIFF_HEADER_BE || value == TIFF_HEADER_LE {
             stream.rewind(4)?;
             return Ok(expected_offset);
@@ -37,7 +39,9 @@ pub(crate) fn parse_exif_tiff_header_offset(stream: &mut IStream) -> AvifResult<
 
 pub(crate) fn parse(stream: &mut IStream) -> AvifResult<()> {
     // unsigned int(32) exif_tiff_header_offset;
-    let offset = stream.read_u32().or(AvifError::invalid_exif_payload())?;
+    let offset = stream
+        .read_u32()
+        .map_err(AvifError::map_invalid_exif_payload)?;
 
     let bytes_left = stream.bytes_left()?;
     let mut sub_stream = stream.sub_stream(&BoxSize::FixedSize(bytes_left))?;

--- a/src/utils/error.rs
+++ b/src/utils/error.rs
@@ -164,11 +164,23 @@ impl AvifError {
         Err(AvifError::InvalidToneMappedImage(object.to_string()))
     }
 
-    pub(crate) fn map_unknown_error<O>(object: O) -> AvifError
+    pub(crate) fn map_unknown_error<E>(error: E) -> AvifError
     where
-        O: std::fmt::Display,
+        E: std::fmt::Display,
     {
         AvifError::on_error();
-        AvifError::UnknownError(object.to_string())
+        AvifError::UnknownError(error.to_string())
+    }
+    pub(crate) fn map_io_error<E>(_: E) -> AvifError {
+        AvifError::on_error();
+        AvifError::IoError
+    }
+    pub(crate) fn map_out_of_memory<E>(_: E) -> AvifError {
+        AvifError::on_error();
+        AvifError::OutOfMemory
+    }
+    pub(crate) fn map_invalid_exif_payload<E>(_: E) -> AvifError {
+        AvifError::on_error();
+        AvifError::InvalidExifPayload
     }
 }

--- a/src/utils/pixels.rs
+++ b/src/utils/pixels.rs
@@ -169,7 +169,7 @@ impl Pixels {
                 let mut cloned_buffer: Vec<u8> = vec![];
                 cloned_buffer
                     .try_reserve_exact(buffer.len())
-                    .or(AvifError::out_of_memory())?;
+                    .map_err(AvifError::map_out_of_memory)?;
                 cloned_buffer.extend_from_slice(buffer);
                 Ok(Pixels::Buffer(cloned_buffer))
             }
@@ -177,7 +177,7 @@ impl Pixels {
                 let mut cloned_buffer16: Vec<u16> = vec![];
                 cloned_buffer16
                     .try_reserve_exact(buffer16.len())
-                    .or(AvifError::out_of_memory())?;
+                    .map_err(AvifError::map_out_of_memory)?;
                 cloned_buffer16.extend_from_slice(buffer16);
                 Ok(Pixels::Buffer16(cloned_buffer16))
             }

--- a/src/utils/reader/y4m.rs
+++ b/src/utils/reader/y4m.rs
@@ -227,14 +227,16 @@ impl Reader for Y4MReader {
             for y in 0..plane_data.height {
                 if self.depth == 8 {
                     let row = image.row_exact_mut(plane, y)?;
-                    reader.read_exact(row).or(AvifError::unknown_error(""))?;
+                    reader
+                        .read_exact(row)
+                        .map_err(AvifError::map_unknown_error)?;
                 } else {
                     let row = image.row16_exact_mut(plane, y)?;
                     let mut pixel_bytes: [u8; 2] = [0, 0];
                     for pixel in row {
                         reader
                             .read_exact(&mut pixel_bytes)
-                            .or(AvifError::unknown_error(""))?;
+                            .map_err(AvifError::map_unknown_error)?;
                         // y4m is always little endian.
                         *pixel = u16::from_le_bytes(pixel_bytes);
                     }

--- a/src/utils/writer/jpeg.rs
+++ b/src/utils/writer/jpeg.rs
@@ -44,7 +44,7 @@ impl Writer for JpegWriter {
                 image.height,
                 image::ExtendedColorType::Rgb8,
             )
-            .or(AvifError::unknown_error("Jpeg encoding failed"))?;
+            .map_err(AvifError::map_unknown_error)?;
         Ok(())
     }
 }

--- a/src/utils/writer/y4m.rs
+++ b/src/utils/writer/y4m.rs
@@ -97,7 +97,7 @@ impl Y4MWriter {
             image.width, image.height
         );
         file.write_all(header.as_bytes())
-            .or(AvifError::io_error())?;
+            .map_err(AvifError::map_io_error)?;
         self.header_written = true;
         Ok(())
     }
@@ -111,7 +111,7 @@ impl Writer for Y4MWriter {
             self.write_header(file, image)?;
             let frame_marker = "FRAME\n";
             file.write_all(frame_marker.as_bytes())
-                .or(AvifError::io_error())?;
+                .map_err(AvifError::map_io_error)?;
         }
         let planes: &[Plane] = if self.write_alpha { &ALL_PLANES } else { &YUV_PLANES };
         for plane in planes {
@@ -123,7 +123,7 @@ impl Writer for Y4MWriter {
                 for y in 0..image.height(plane) {
                     let row = image.row(plane, y as u32)?;
                     let pixels = &row[..image.width(plane)];
-                    file.write_all(pixels).or(AvifError::io_error())?;
+                    file.write_all(pixels).map_err(AvifError::map_io_error)?;
                 }
             } else {
                 for y in 0..image.height(plane) {
@@ -134,7 +134,8 @@ impl Writer for Y4MWriter {
                     for &pixel16 in pixels16 {
                         pixels.extend_from_slice(&pixel16.to_le_bytes());
                     }
-                    file.write_all(&pixels[..]).or(AvifError::io_error())?;
+                    file.write_all(&pixels[..])
+                        .map_err(AvifError::map_io_error)?;
                 }
             }
         }


### PR DESCRIPTION
Otherwise the AvifError is always constructed and always calls AvifError::on_error(), even if Ok().