### PR TITLE
Explicitly qualify image:: and rgb::Image in rgb.rs

### DIFF
--- a/c_api_tests/reformat_tests.cc
+++ b/c_api_tests/reformat_tests.cc
@@ -73,6 +73,7 @@ TEST(ReformatTest, YUVToRGBConversion) {
     memcpy(image->yuvPlanes[2], kYuv[p] + kVOffset, kPlaneSize);
     avifRGBImage rgb;
     avifRGBImageSetDefaults(&rgb, image.get());
+    rgb.format = AVIF_RGB_FORMAT_RGBA;
     std::vector<uint8_t> rgb_pixels(kWidth * kHeight * 4);
     rgb.pixels = rgb_pixels.data();
     rgb.rowBytes = kWidth * 4;


### PR DESCRIPTION
Avoids VSCode error complaining about missing format field in image::Image in shuffle_channels_to().
Also better map from image::Image to rgb::Image in create_from_yuv().