### PR TITLE
Use f32 instead of i32 for quality

### DIFF
--- a/src/capi/encoder.rs
+++ b/src/capi/encoder.rs
@@ -101,17 +101,17 @@ impl From<&avifEncoder> for MutableSettings {
                 quality_from_quantizers(encoder.minQuantizer, encoder.maxQuantizer)
             } else {
                 encoder.quality
-            },
+            } as f32,
             quality_alpha: if encoder.qualityAlpha == -1 {
                 quality_from_quantizers(encoder.minQuantizerAlpha, encoder.maxQuantizerAlpha)
             } else {
                 encoder.qualityAlpha
-            },
+            } as f32,
             quality_gainmap: if encoder.qualityGainMap == -1 {
                 quality_from_quantizers(encoder.minQuantizer, encoder.maxQuantizer)
             } else {
                 encoder.qualityGainMap
-            },
+            } as f32,
             tiling_mode: if encoder.autoTiling == AVIF_TRUE {
                 TilingMode::Auto
             } else {

--- a/src/codecs/aom.rs
+++ b/src/codecs/aom.rs
@@ -251,10 +251,10 @@ impl Encoder for Aom {
                 codec_control!(
                     self,
                     aome_enc_control_id_AOME_SET_CQ_LEVEL,
-                    config.quantizer
+                    config.quantizer()
                 );
             }
-            if config.quantizer == 0 {
+            if config.quantizer() == 0 {
                 codec_control!(self, aome_enc_control_id_AV1E_SET_LOSSLESS, 1);
             }
             if config.tile_rows_log2 != 0 {
@@ -368,7 +368,7 @@ impl Encoder for Aom {
                 return AvifError::not_implemented();
             }
             let last_config = self.config.unwrap_ref();
-            if last_config.quantizer != config.quantizer {
+            if last_config.quantizer() != config.quantizer() {
                 if aom_config.rc_end_usage == aom_rc_mode_AOM_VBR
                     || aom_config.rc_end_usage == aom_rc_mode_AOM_CBR
                 {
@@ -392,13 +392,13 @@ impl Encoder for Aom {
                     codec_control!(
                         self,
                         aome_enc_control_id_AOME_SET_CQ_LEVEL,
-                        config.quantizer
+                        config.quantizer()
                     );
                 }
                 codec_control!(
                     self,
                     aome_enc_control_id_AV1E_SET_LOSSLESS,
-                    if config.quantizer == 0 { 1 } else { 0 }
+                    if config.quantizer() == 0 { 1 } else { 0 }
                 );
             }
             if last_config.tile_rows_log2 != config.tile_rows_log2 {

--- a/src/encoder/mod.rs
+++ b/src/encoder/mod.rs
@@ -94,9 +94,9 @@ impl TilingMode {
 
 #[derive(Clone, Copy, Debug)]
 pub struct MutableSettings {
-    pub quality: i32,
-    pub quality_alpha: i32,
-    pub quality_gainmap: i32,
+    pub quality: f32,
+    pub quality_alpha: f32,
+    pub quality_gainmap: f32,
     pub tiling_mode: TilingMode,
     pub scaling_mode: ScalingMode,
 }
@@ -104,9 +104,9 @@ pub struct MutableSettings {
 impl Default for MutableSettings {
     fn default() -> Self {
         Self {
-            quality: 60,
-            quality_alpha: 60,
-            quality_gainmap: 60,
+            quality: 60.0,
+            quality_alpha: 60.0,
+            quality_gainmap: 60.0,
             tiling_mode: Default::default(),
             scaling_mode: Default::default(),
         }
@@ -626,7 +626,7 @@ impl Encoder {
                         // Encoding the least significant bits of a sample does not
                         // make any sense if the other bits are lossily compressed.
                         // Encode the most significant bits losslessly.
-                        quality = 100;
+                        quality = 100.0;
                     }
                     bit_depth_extension_image =
                         Self::create_bit_depth_extension_image(image, item)?;
@@ -637,7 +637,7 @@ impl Encoder {
             let encoder_config = EncoderConfig {
                 tile_rows_log2,
                 tile_columns_log2,
-                quantizer: ((100 - quality) * 63 + 50) / 100,
+                quality,
                 disable_lagged_output: self.alpha_present,
                 is_single_image,
                 speed: self.settings.speed,

--- a/tests/encoder_tests.rs
+++ b/tests/encoder_tests.rs
@@ -54,7 +54,7 @@ fn encode_decode(
     let settings = encoder::Settings {
         speed: Some(10),
         mutable: encoder::MutableSettings {
-            quality: 90,
+            quality: 90.0,
             tiling_mode,
             ..Default::default()
         },
@@ -153,8 +153,8 @@ fn encode_decode_grid_impl(
         speed: Some(10),
         mutable: encoder::MutableSettings {
             // Encode losslessly for easier comparison of outputs.
-            quality: 100,
-            quality_alpha: 100,
+            quality: 100.0,
+            quality_alpha: 100.0,
             ..Default::default()
         },
         ..Default::default()
@@ -425,7 +425,7 @@ fn encode_decode_sequence(
         speed: Some(10),
         repetition_count,
         mutable: encoder::MutableSettings {
-            quality: 50,
+            quality: 50.0,
             ..Default::default()
         },
         ..Default::default()
@@ -500,7 +500,7 @@ fn sequence_alpha_combinations(first_image_has_alpha: bool) -> AvifResult<()> {
     let settings = encoder::Settings {
         speed: Some(10),
         mutable: encoder::MutableSettings {
-            quality: 50,
+            quality: 50.0,
             ..Default::default()
         },
         ..Default::default()
@@ -612,7 +612,7 @@ fn progressive_quality_change(use_grid: bool) -> AvifResult<()> {
         speed: Some(10),
         extra_layer_count: 1,
         mutable: encoder::MutableSettings {
-            quality: 2,
+            quality: 2.0,
             ..Default::default()
         },
         ..Default::default()
@@ -624,7 +624,7 @@ fn progressive_quality_change(use_grid: bool) -> AvifResult<()> {
     } else {
         encoder.add_image(&image)?;
     }
-    settings.mutable.quality = 90;
+    settings.mutable.quality = 90.0;
     encoder.update_settings(&settings.mutable)?;
     if use_grid {
         encoder.add_image_grid(2, 1, &images)?;
@@ -652,7 +652,7 @@ fn progressive_dimension_change(scaling_fraction: IFraction, use_grid: bool) -> 
         speed: Some(10),
         extra_layer_count: 1,
         mutable: encoder::MutableSettings {
-            quality: 100,
+            quality: 100.0,
             scaling_mode: ScalingMode {
                 horizontal: scaling_fraction,
                 vertical: scaling_fraction,
@@ -696,7 +696,7 @@ fn progressive_same_layers() -> AvifResult<()> {
         extra_layer_count: 3,
         speed: Some(10),
         mutable: encoder::MutableSettings {
-            quality: 50,
+            quality: 50.0,
             ..Default::default()
         },
         ..Default::default()
@@ -721,7 +721,7 @@ fn progressive_incorrect_number_of_layers() -> AvifResult<()> {
         speed: Some(10),
         extra_layer_count: 1,
         mutable: encoder::MutableSettings {
-            quality: 50,
+            quality: 50.0,
             ..Default::default()
         },
         ..Default::default()
@@ -795,7 +795,7 @@ fn gainmap_base_image_sdr() -> AvifResult<()> {
     let settings = encoder::Settings {
         speed: Some(10),
         mutable: encoder::MutableSettings {
-            quality: 80,
+            quality: 80.0,
             ..Default::default()
         },
         ..Default::default()
@@ -847,7 +847,7 @@ fn gainmap_base_image_hdr() -> AvifResult<()> {
     let settings = encoder::Settings {
         speed: Some(10),
         mutable: encoder::MutableSettings {
-            quality: 80,
+            quality: 80.0,
             ..Default::default()
         },
         ..Default::default()
@@ -918,9 +918,9 @@ fn alpha_transformative_properties() -> AvifResult<()> {
     let mut encoder = encoder::Encoder::create_with_settings(&encoder::Settings {
         speed: Some(10),
         mutable: MutableSettings {
-            quality: 100,
-            quality_alpha: 100,
-            quality_gainmap: 100,
+            quality: 100.0,
+            quality_alpha: 100.0,
+            quality_gainmap: 100.0,
             ..Default::default()
         },
         ..Default::default()
@@ -1310,8 +1310,8 @@ fn quality_categories() -> AvifResult<()> {
     let settings = encoder::Settings {
         speed: Some(10),
         mutable: encoder::MutableSettings {
-            quality: 5,
-            quality_alpha: 100,
+            quality: 5.0,
+            quality_alpha: 100.0,
             ..Default::default()
         },
         ..Default::default()

--- a/tests/lossless_test.rs
+++ b/tests/lossless_test.rs
@@ -100,7 +100,7 @@ fn lossless_roundtrip(
     let settings = encoder::Settings {
         speed: Some(10),
         mutable: encoder::MutableSettings {
-            quality: 100,
+            quality: 100.0,
             ..Default::default()
         },
         ..Default::default()

--- a/tests/mini_test.rs
+++ b/tests/mini_test.rs
@@ -80,9 +80,9 @@ fn encode_decode(
         speed: Some(10),
         header_format: HeaderFormat::Mini,
         mutable: encoder::MutableSettings {
-            quality: 90,
-            quality_gainmap: 90,
-            quality_alpha: 90,
+            quality: 90.0,
+            quality_gainmap: 90.0,
+            quality_alpha: 90.0,
             ..Default::default()
         },
         ..Default::default()

--- a/tests/sample_transform_test.rs
+++ b/tests/sample_transform_test.rs
@@ -41,7 +41,7 @@ fn lossless_sample_transform_roundtrip() -> AvifResult<()> {
     let settings = encoder::Settings {
         speed: Some(10),
         mutable: encoder::MutableSettings {
-            quality: 100,
+            quality: 100.0,
             ..Default::default()
         },
         recipe: Recipe::BitDepthExtension8b8b,


### PR DESCRIPTION
f32 can represent positive integers till 100 exactly, and provide extra precision for codecs supporting it, if added to CrabbyAvif in the future.

Keep quality in EncoderConfig and add quantizer() function.