### PR TITLE
Add read_image() and write_png() in test/utils

### DIFF
--- a/src/bin/impl/mod.rs
+++ b/src/bin/impl/mod.rs
@@ -27,14 +27,6 @@ use crabby_avif::utils::IFraction;
 use crabby_avif::utils::UFraction;
 use crabby_avif::*;
 
-#[cfg(all(feature = "encoder", feature = "gif"))]
-use crabby_avif::utils::reader::gif::GifReader;
-#[cfg(all(feature = "encoder", feature = "jpeg"))]
-use crabby_avif::utils::reader::jpeg::JpegReader;
-#[cfg(all(feature = "encoder", feature = "png"))]
-use crabby_avif::utils::reader::png::PngReader;
-#[cfg(feature = "encoder")]
-use crabby_avif::utils::reader::y4m::Y4MReader;
 #[cfg(feature = "encoder")]
 use crabby_avif::utils::reader::Config;
 #[cfg(feature = "encoder")]
@@ -742,21 +734,7 @@ fn read_file(filepath: &String) -> io::Result<Vec<u8>> {
 #[cfg(feature = "encoder")]
 fn encode(args: &CommandLineArgs, input_file: &str, output_file: &str) -> AvifResult<()> {
     const DEFAULT_ENCODE_QUALITY: f32 = 90.0;
-    let input_extension = get_extension(input_file);
-    let mut reader: Box<dyn Reader> = match input_extension.as_str() {
-        "y4m" => Box::new(Y4MReader::create(input_file)?),
-        #[cfg(feature = "jpeg")]
-        "jpg" | "jpeg" => Box::new(JpegReader::create(input_file)?),
-        #[cfg(feature = "png")]
-        "png" => Box::new(PngReader::create(input_file)?),
-        #[cfg(feature = "gif")]
-        "gif" => Box::new(GifReader::create(input_file)?),
-        _ => {
-            return Err(AvifError::UnknownError(format!(
-                "Unknown input file extension ({input_extension})"
-            )));
-        }
-    };
+    let mut reader = <dyn Reader>::create(input_file)?;
     let reader_config = Config {
         yuv_format: args.yuv_format,
         depth: args.depth,

--- a/src/gainmap.rs
+++ b/src/gainmap.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::image::YuvRange;
+use crate::internal_utils::TryClone;
 use crate::utils::*;
 use crate::*;
 
@@ -97,6 +98,17 @@ impl PartialEq for GainMap {
             && self.alt_plane_count == other.alt_plane_count
             && self.alt_plane_depth == other.alt_plane_depth
             && self.alt_clli == other.alt_clli
+    }
+}
+
+impl GainMap {
+    pub(crate) fn try_deep_clone(&self) -> AvifResult<Self> {
+        Ok(GainMap {
+            image: self.image.try_deep_clone()?,
+            metadata: self.metadata.clone(),
+            alt_icc: self.alt_icc.try_clone()?,
+            ..*self
+        })
     }
 }
 

--- a/src/image.rs
+++ b/src/image.rs
@@ -123,6 +123,33 @@ impl Image {
         }
     }
 
+    pub(crate) fn try_deep_clone(&self) -> AvifResult<Self> {
+        let mut image = self.shallow_clone();
+        for plane in ALL_PLANES.iter().filter(|p| self.has_plane(**p)) {
+            // Allocate and copy row by row to avoid carrying large row padding
+            // over if any.
+            image.allocate_plane(*plane)?;
+            for y in 0..self.height(*plane) as u32 {
+                if self.depth <= 8 {
+                    image
+                        .row_mut(*plane, y)?
+                        .copy_from_slice(self.row(*plane, y)?);
+                } else {
+                    image
+                        .row16_mut(*plane, y)?
+                        .copy_from_slice(self.row16(*plane, y)?);
+                }
+            }
+        }
+        image.exif = self
+            .exif
+            .try_clone()
+            .map_err(AvifError::map_out_of_memory)?;
+        image.icc = self.icc.try_clone().map_err(AvifError::map_out_of_memory)?;
+        image.xmp = self.xmp.try_clone().map_err(AvifError::map_out_of_memory)?;
+        Ok(image)
+    }
+
     pub(crate) fn is_supported_depth(depth: u8) -> bool {
         matches!(depth, 8 | 10 | 12 | 16)
     }
@@ -379,30 +406,44 @@ impl Image {
         self.free_planes(&[Plane::U, Plane::V])
     }
 
-    pub(crate) fn allocate_planes_with_default_values(
+    fn allocate_plane(&mut self, plane: Plane) -> AvifResult<()> {
+        // Rust has no idiomatic way to allocate memory without initializing it.
+        const DEFAULT_VALUE: u16 = 0; // The default value does not matter.
+        self.allocate_plane_with_default_value(plane, DEFAULT_VALUE)
+    }
+
+    fn allocate_plane_with_default_value(
         &mut self,
-        category: Category,
-        default_values: [u16; 4],
+        plane: Plane,
+        default_value: u16,
     ) -> AvifResult<()> {
-        let pixel_size: usize = if self.depth == 8 { 1 } else { 2 };
-        for plane in category.planes() {
-            let plane = *plane;
-            let plane_index = plane.as_usize();
-            let width = round2_usize(self.width(plane));
-            let plane_size = checked_mul!(width, round2_usize(self.height(plane)))?;
-            if plane_size == 0 {
-                self.planes[plane_index] = None;
-                self.row_bytes[plane_index] = 0;
-                continue;
-            }
+        let plane_index = plane.as_usize();
+        let width = round2_usize(self.width(plane));
+        let plane_size = checked_mul!(width, round2_usize(self.height(plane)))?;
+        if plane_size == 0 {
+            self.planes[plane_index] = None;
+            self.row_bytes[plane_index] = 0;
+        } else {
             self.planes[plane_index] = Some(if self.depth == 8 {
                 Pixels::Buffer(Vec::new())
             } else {
                 Pixels::Buffer16(Vec::new())
             });
             let pixels = self.planes[plane_index].unwrap_mut();
-            pixels.resize(plane_size, default_values[plane_index])?;
+            pixels.resize(plane_size, default_value)?;
+            let pixel_size: usize = if self.depth == 8 { 1 } else { 2 };
             self.row_bytes[plane_index] = u32_from_usize(checked_mul!(width, pixel_size)?)?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn allocate_planes_with_default_values(
+        &mut self,
+        category: Category,
+        default_values: [u16; 4],
+    ) -> AvifResult<()> {
+        for plane in category.planes() {
+            self.allocate_plane_with_default_value(*plane, default_values[plane.as_usize()])?;
         }
         Ok(())
     }

--- a/src/utils/reader/avif.rs
+++ b/src/utils/reader/avif.rs
@@ -1,0 +1,73 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::decoder::Decoder;
+use crate::gainmap::GainMap;
+use crate::AvifError;
+use crate::AvifResult;
+use crate::*;
+
+use super::Config;
+use super::Reader;
+
+pub struct AvifReader {
+    path: String,
+    decoder: Decoder,
+}
+
+impl AvifReader {
+    pub fn create(path: &str) -> AvifResult<Self> {
+        let path = path.to_string();
+        let mut decoder = Decoder::default();
+        decoder.set_io_file(&path)?;
+        decoder.parse()?;
+        Ok(Self { path, decoder })
+    }
+}
+
+impl Reader for AvifReader {
+    fn read_frame(&mut self, config: &Config) -> AvifResult<(Image, u64, Option<GainMap>)> {
+        self.decoder.next_image()?;
+        let image = self.decoder.image().unwrap();
+        if let Some(yuv_format) = config.yuv_format {
+            if yuv_format != image.yuv_format {
+                return AvifError::not_implemented();
+            }
+        }
+        if let Some(depth) = config.depth {
+            if depth != image.depth {
+                return AvifError::not_implemented();
+            }
+        }
+        if let Some(matrix_coefficients) = config.matrix_coefficients {
+            if matrix_coefficients != image.matrix_coefficients {
+                return AvifError::not_implemented();
+            }
+        }
+        Ok((
+            image.try_deep_clone()?,
+            (self.decoder.image_timing().duration * 1000.0).round() as u64,
+            if self.decoder.gainmap_present() {
+                Some(self.decoder.gainmap().try_deep_clone()?)
+            } else {
+                None
+            },
+        ))
+    }
+
+    fn has_more_frames(&mut self) -> bool {
+        self.decoder.image_index() < 0
+            || (self.decoder.image_index() as u32) < self.decoder.image_count()
+    }
+}

--- a/src/utils/reader/mod.rs
+++ b/src/utils/reader/mod.rs
@@ -15,6 +15,7 @@
 // Not all sub-modules are used by all targets. Ignore dead code warnings.
 #![allow(dead_code)]
 
+pub mod avif;
 #[cfg(feature = "gif")]
 pub mod gif;
 #[cfg(feature = "jpeg")]
@@ -30,6 +31,7 @@ mod xmp;
 
 use crate::gainmap::GainMap;
 use crate::image::Image;
+use crate::AvifError;
 use crate::AvifResult;
 use crate::MatrixCoefficients;
 use crate::PixelFormat;
@@ -47,6 +49,55 @@ pub struct Config {
 }
 
 pub trait Reader {
+    // Returns the next frame, its duration in milliseconds, and the gain map if any.
     fn read_frame(&mut self, config: &Config) -> AvifResult<(Image, u64, Option<GainMap>)>;
+    // Returns true if the last call to read_frame() returned another frame than the last frame.
+    // Meaningless if read_frame() was never called or if read_frame() returned an error.
     fn has_more_frames(&mut self) -> bool;
+}
+
+impl dyn Reader {
+    pub fn create(path: &str) -> AvifResult<Box<dyn Reader>> {
+        Ok(
+            match std::path::Path::new(path)
+                .extension()
+                .and_then(|s| s.to_str())
+                .unwrap_or("")
+                .to_lowercase()
+                .as_str()
+            {
+                "y4m" => Box::new(y4m::Y4MReader::create(path)?),
+                #[cfg(feature = "jpeg")]
+                "jpg" | "jpeg" => Box::new(jpeg::JpegReader::create(path)?),
+                #[cfg(not(feature = "jpeg"))]
+                "jpg" | "jpeg" => {
+                    return AvifError::unknown_error(format!(
+                    "Cannot read {path} because CrabbyAvif was not compiled with the jpeg feature"
+                ))
+                }
+                #[cfg(feature = "png")]
+                "png" => Box::new(png::PngReader::create(path)?),
+                #[cfg(not(feature = "png"))]
+                "png" => {
+                    return AvifError::unknown_error(format!(
+                    "Cannot read {path} because CrabbyAvif was not compiled with the png feature"
+                ))
+                }
+                #[cfg(feature = "gif")]
+                "gif" => Box::new(gif::GifReader::create(path)?),
+                #[cfg(not(feature = "gif"))]
+                "gif" => {
+                    return AvifError::unknown_error(format!(
+                    "Cannot read {path} because CrabbyAvif was not compiled with the gif feature"
+                ))
+                }
+                "avif" => Box::new(avif::AvifReader::create(path)?),
+                _ => {
+                    return AvifError::unknown_error(format!(
+                        "Unknown input file extension for {path}"
+                    ))
+                }
+            },
+        )
+    }
 }

--- a/tests/avif.rs
+++ b/tests/avif.rs
@@ -1,0 +1,26 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![cfg(any(feature = "dav1d", feature = "android_mediacodec"))]
+
+use crabby_avif::*;
+
+mod utils;
+use utils::*;
+
+#[test]
+fn read_image_avif_test() -> AvifResult<()> {
+    read_image(&get_test_file("alpha.avif"))?;
+    Ok(())
+}

--- a/tests/png.rs
+++ b/tests/png.rs
@@ -1,0 +1,38 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![cfg(feature = "png")]
+
+use crabby_avif::image::*;
+use crabby_avif::*;
+
+mod utils;
+use utils::*;
+
+use tempfile::NamedTempFile;
+use test_case::test_matrix;
+
+#[test_matrix(
+    [8, 16],
+    [false, true]
+)]
+fn roundtrip(depth: u8, alpha: bool) -> AvifResult<()> {
+    let image = generate_gradient_image(1, 1, depth, PixelFormat::Yuv444, YuvRange::Full, alpha)?;
+    let path = NamedTempFile::new().unwrap().into_temp_path();
+    let path = format!("{}.png", path.to_str().unwrap());
+    write_png(&image, &path)?;
+    let decoded = read_image(&path)?;
+    are_images_equal(&image, &decoded)?;
+    Ok(())
+}

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -39,6 +39,20 @@ pub fn get_decoder(filename: &str) -> decoder::Decoder {
     decoder
 }
 
+pub fn read_image(path: &str) -> AvifResult<Image> {
+    use crabby_avif::utils::reader::{Config, Reader};
+    Ok(<dyn Reader>::create(path)?
+        .read_frame(&Config::default())?
+        .0)
+}
+
+#[cfg(feature = "png")]
+pub fn write_png(image: &Image, filename: &str) -> AvifResult<()> {
+    use crabby_avif::utils::writer::{png::PngWriter, Writer};
+    let mut file = std::fs::File::create(filename).unwrap();
+    PngWriter::default().write_frame(&mut file, image)
+}
+
 fn full_to_limited_pixel(min: u32, max: u32, full: u32, v: u16) -> u16 {
     let v = v as u32;
     let v = (((v * (max - min)) + (full / 2)) / full) + min;

--- a/tests/y4m.rs
+++ b/tests/y4m.rs
@@ -27,14 +27,6 @@ use std::fs::File;
 use tempfile::NamedTempFile;
 use test_case::test_matrix;
 
-fn get_tempfile() -> String {
-    let file = NamedTempFile::new().expect("unable to open tempfile");
-    let path = file.into_temp_path();
-    let filename = String::from(path.to_str().unwrap());
-    let _ = path.close();
-    filename
-}
-
 #[test_matrix(
     [100, 121],
     [200, 107],
@@ -56,17 +48,19 @@ fn roundtrip(
         return Ok(());
     }
     let image1 = generate_gradient_image(width, height, depth, yuv_format, yuv_range, alpha)?;
-    let output_filename = get_tempfile();
+    let path = NamedTempFile::new().unwrap().into_temp_path();
+    let path = format!("{}.y4m", path.to_str().unwrap());
     // Write the image.
     {
         let mut writer = Y4MWriter::create(false);
-        let mut output_file =
-            File::create(output_filename.clone()).expect("output file creation failed");
+        let mut output_file = File::create(path.clone()).expect("output file creation failed");
         writer.write_frame(&mut output_file, &image1)?;
     }
     // Read the image.
-    let mut reader = Y4MReader::create(&output_filename)?;
+    let mut reader = Y4MReader::create(&path)?;
     let (image2, _, _) = reader.read_frame(&Config::default())?;
     are_images_equal(&image1, &image2)?;
+    // Read the image using the generic test utils API.
+    are_images_equal(&image1, &read_image(&path)?)?;
     Ok(())
 }


### PR DESCRIPTION
read_image() and write_png() are convenient functions for debugging.
Add AvifReader as a Reader impl for AVIF files.
Add Image::try_deep_clone() to be used by AvifReader.
Add Reader::create() to redirect to the Reader impl based on file ext.
Add tests.