### PR TITLE
Add c_api_tests/.clang-format

### DIFF
--- a/c_api_tests/.clang-format
+++ b/c_api_tests/.clang-format
@@ -1,0 +1,2 @@
+Language: Cpp
+BasedOnStyle: Google


### PR DESCRIPTION
So `clang-format-18 -i -style=file c_api_tests/*.cc` is a no-op.